### PR TITLE
workflow: Build mistserver only on tag push or manifest changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+indent_size = 2
 
 [*.go]
 indent_style = tab

--- a/.github/workflows/mistserver.yaml
+++ b/.github/workflows/mistserver.yaml
@@ -67,7 +67,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Setup env
-        run: echo GOARCH="${{ matrix.arch }}" >> $GITHUB_ENV
+        run: echo ARCH="${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -91,12 +91,16 @@ jobs:
         with:
           path: |
             livepeer-in-a-box/build
-          key: ${{ runner.os }}-build-${{ hashFiles('**/Makefile') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-build-${{ hashFiles('**/Makefile') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-${{ matrix.arch }}-build-
 
       - name: Compile mist binaries
         run: |
+          if [[ "${ARCH}" == "arm64" ]]; then
+            export CFLAGS="$CFLAGS --target=arm64-apple-macos11"
+            export LDFLAGS="$LDFLAGS --target=arm64-apple-macos11"
+          fi
           command -v brew && brew install coreutils
           cd livepeer-in-a-box/
           mkdir -p releases/ build/ bin/
@@ -122,8 +126,8 @@ jobs:
 
       - name: Archive built binaries
         run: |
-          cd bin/
-          tar -czvf "../releases/livepeer-mistserver-darwin-${GOARCH}.tar.gz" ./*
+          cd livepeer-in-a-box/bin/
+          tar -czvf "../releases/livepeer-mistserver-darwin-${ARCH}.tar.gz" ./*
 
       - name: Upload mist binaries as build artifacts
         uses: actions/upload-artifact@master

--- a/.github/workflows/mistserver.yaml
+++ b/.github/workflows/mistserver.yaml
@@ -138,6 +138,7 @@ jobs:
   release:
     name: Create release for mist binaries
     runs-on: ubuntu-20.04
+    if: ${{ github.ref_type == 'tag' }}
     needs:
       - linux
       - macos

--- a/.github/workflows/mistserver.yaml
+++ b/.github/workflows/mistserver.yaml
@@ -57,9 +57,18 @@ jobs:
           path: livepeer-in-a-box/releases/
 
   macos:
-    name: Build mist binaries for macOS platform
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - arm64
+          - amd64
+    name: Build mist binaries for macOS platform (${{ matrix.arch }})
     runs-on: macos-11
     steps:
+      - name: Setup env
+        run: echo GOARCH="${{ matrix.arch }}" >> $GITHUB_ENV
+
       - name: Check out code
         uses: actions/checkout@v3
         with:
@@ -87,14 +96,11 @@ jobs:
             ${{ runner.os }}-build-
 
       - name: Compile mist binaries
-        shell: bash
         run: |
           command -v brew && brew install coreutils
           cd livepeer-in-a-box/
           mkdir -p releases/ build/ bin/
           make mistserver
-          cd bin/
-          tar -czvf "../releases/livepeer-mistserver-darwin-amd64.tar.gz" ./*
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: match-tag
@@ -113,6 +119,11 @@ jobs:
           app-notarization-password: ${{ secrets.CI_MACOS_NOTARIZATION_PASSWORD }}
           binary-path: "livepeer-in-a-box/bin/"
           app-bundle-id: "org.livepeer.mistserver"
+
+      - name: Archive built binaries
+        run: |
+          cd bin/
+          tar -czvf "../releases/livepeer-mistserver-darwin-${GOARCH}.tar.gz" ./*
 
       - name: Upload mist binaries as build artifacts
         uses: actions/upload-artifact@master

--- a/.github/workflows/mistserver.yaml
+++ b/.github/workflows/mistserver.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main"
+      - "hjp/*"
+    paths:
+      - ".github/workflows/mistserver.yaml"
     tags:
       - "mist-v*"
 
@@ -97,7 +100,7 @@ jobs:
         id: match-tag
         with:
           text: ${{ github.ref_name }}
-          regex: '^(master|main|mist-v[0-9]+\.\d+\.\d+)$'
+          regex: '^(master|main|mist-v[0-9]+\.\d+(\.\d+)?)$'
 
       - name: Codesign and notarize binaries
         if: ${{ steps.match-tag.outputs.match != '' }}
@@ -134,7 +137,7 @@ jobs:
         id: match-tag
         with:
           text: ${{ github.ref_name }}
-          regex: '^mist-v([0-9]+\.\d+\.\d+)$'
+          regex: '^mist-v([0-9]+\.\d+(\.\d+)?)$'
 
       - name: Download artifacts from build stages
         if: ${{ steps.match-tag.outputs.match != '' }}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build/compiled/lib/libsrt.a: build/compiled/lib/libmbedtls.a
 	&& cd $(buildpath)/srt \
 	&& mkdir build \
 	&& cd build \
-	&& cmake .. -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled -D USE_ENCLIB=mbedtls -D ENABLE_SHARED=false \
+	&& cmake .. -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled -D USE_ENCLIB=mbedtls -D ENABLE_SHARED=false -D ENABLE_APPS=false \
 	&& make -j${PROC_COUNT} install
 
 .PHONY: mistserver

--- a/Makefile
+++ b/Makefile
@@ -24,33 +24,30 @@ build/compiled/lib/libmbedtls.a:
 	&& export LD_LIBRARY_PATH=$(buildpath)/compiled/lib \
 	&& export C_INCLUDE_PATH=$(buildpath)/compiled/include \
 	&& git clone -b dtls_srtp_support --depth=1 https://github.com/livepeer/mbedtls.git $(buildpath)/mbedtls \
-  && cd $(buildpath)/mbedtls \
-  && mkdir build \
-  && cd build \
-  && cmake -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled .. \
-  && make -j$(nproc) install
+	&& cd $(buildpath)/mbedtls \
+	&& mkdir build \
+	&& cd build \
+	&& cmake -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled .. \
+	&& make -j$(PROC_COUNT) install
 
 build/compiled/lib/libsrtp2.a:
 	git clone https://github.com/cisco/libsrtp.git $(buildpath)/libsrtp \
-  && cd $(buildpath)/libsrtp \
-  && mkdir build \
-  && cd build \
-  && cmake -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled .. \
-  && make -j$(nproc) install
+	&& cd $(buildpath)/libsrtp \
+	&& mkdir build \
+	&& cd build \
+	&& cmake -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled .. \
+	&& make -j$(PROC_COUNT) install
 
 build/compiled/lib/libsrt.a: build/compiled/lib/libmbedtls.a
-build/compiled/lib/libsrt.a:
 	git clone https://github.com/Haivision/srt.git $(buildpath)/srt \
-  && cd $(buildpath)/srt \
-  && mkdir build \
-  && cd build \
-  && cmake .. -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled -D USE_ENCLIB=mbedtls -D ENABLE_SHARED=false \
-  && make -j$(nproc) install
-
-mistserver: build/compiled/lib/libmbedtls.a build/compiled/lib/libsrtp2.a build/compiled/lib/libsrt.a
+	&& cd $(buildpath)/srt \
+	&& mkdir build \
+	&& cd build \
+	&& cmake .. -DCMAKE_INSTALL_PREFIX=$(buildpath)/compiled -D USE_ENCLIB=mbedtls -D ENABLE_SHARED=false \
+	&& make -j${PROC_COUNT} install
 
 .PHONY: mistserver
-mistserver:
+mistserver: build/compiled/lib/libmbedtls.a build/compiled/lib/libsrtp2.a build/compiled/lib/libsrt.a
 	set -x \
 	export PKG_CONFIG_PATH=$(buildpath)/compiled/lib/pkgconfig \
 	export LD_LIBRARY_PATH=~$(buildpath)/compiled/lib \

--- a/cmd/livepeer-log/livepeer-log.go
+++ b/cmd/livepeer-log/livepeer-log.go
@@ -26,10 +26,10 @@ func main() {
 	// If we're being called for our OWN -j, respond accordingly
 	if len(rest) == 0 && procname == "-j" {
 		printJsonInfo(mistconnector.MistConfig{
-			Name:     "Livepeer Logger",
+			Name:         "Livepeer Logger",
 			FriendlyName: "Logger for livepeer-* applications",
-			Description:     "Logger for other livepeer-whatever applications. No need to add directly.",
-			Version:  "0.0.1",
+			Description:  "Logger for other livepeer-whatever applications. No need to add directly.",
+			Version:      "0.0.1",
 		})
 		os.Exit(0)
 	}
@@ -41,10 +41,10 @@ func main() {
 	}
 	if procname == "livepeer-victoria-metrics" && dashJ {
 		printJsonInfo(mistconnector.MistConfig{
-			Name:     "Livepeer Victoria Metrics",
+			Name:         "Livepeer Victoria Metrics",
 			FriendlyName: "Livepeer-in-a-Box packaged Victoria Metrics",
-			Description:     "Livepeer-in-a-Box packaged Victoria Metrics. Comes with some built-in scrape configs for dev.",
-			Version:  "0.0.1",
+			Description:  "Livepeer-in-a-Box packaged Victoria Metrics. Comes with some built-in scrape configs for dev.",
+			Version:      "0.0.1",
 			Required: map[string]mistconnector.MistOptional{
 				"promscrape.config": {
 					Name:    "promscrape.config",


### PR DESCRIPTION
Update pattern for when the release and codesign actions take place