### PR TITLE
e2e_test: integrate MistLoadTest to verify streaming

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -12,7 +12,8 @@ steps:
     commands:
       - go mod download
       - export CI_CATALYST_TEST_IMAGE="${DRONE_REPO}:${DRONE_BUILD_NUMBER}"
-      - docker build --tag "$CI_CATALYST_TEST_IMAGE" --build-arg GIT_VERSION="$DRONE_COMMIT_SHA" .
+      # TODO: implement manifest.yaml auto-updates and dump --no-cache
+      - docker build --no-cache --tag "$CI_CATALYST_TEST_IMAGE" --build-arg GIT_VERSION="$DRONE_COMMIT_SHA" .
       - 'parallel go test -v ./test/e2e/* --image "$CI_CATALYST_TEST_IMAGE" --network "catalyst-test-${DRONE_BUILD_NUMBER}-0{}" ::: $(seq 0 2)'
 
 trigger:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ COPY --from=gobuild	/build/bin/	/usr/bin/
 
 EXPOSE	1935	4242	8080	8889/udp
 
+# MistController starts all binaries required for catalyst
 CMD	["/usr/bin/MistController", "-c", "/etc/livepeer/catalyst.json"]

--- a/test/copy-mist-binaries.sh
+++ b/test/copy-mist-binaries.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -x
+
+if [ $# -eq 0 ]; then
+    echo "Missing output directory as argument"
+    exit 1
+fi
+
+# Get one of the container IDs
+CID=$(docker ps | grep catalyst | awk '{ print $1 }' | head -1)
+
+# Copy Mist tester binaries to CI host
+docker cp "$CID":/usr/bin/MistLoadTest /$1
+docker cp "$CID":/usr/bin/MistAnalyserHLS /$1 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2,14 +2,17 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +107,7 @@ func TestMultiNodeCatalyst(t *testing.T) {
 	defer p.Kill()
 
 	requireReplicatedStream(t, c2)
+	requireProtocolLoad(t, c2)
 	requireStreamRedirection(t, c1, c2)
 }
 
@@ -293,9 +297,11 @@ func requireReplicatedStream(t *testing.T, c *catalystContainer) {
 		content := string(body)
 		for _, expected := range []string{"RESOLUTION=1920x1080", "FRAME-RATE=30", "index.m3u8"} {
 			if !strings.Contains(content, expected) {
+				glog.Info("Failed to get HLS manifest")
 				return false
 			}
 		}
+		glog.Info("Got HLS manifest!")
 		return true
 	}
 	require.Eventually(t, correctStream, 5*time.Minute, time.Second)
@@ -348,4 +354,92 @@ func requireStreamRedirection(t *testing.T, c1 *catalystContainer, c2 *catalystC
 		return false
 	}
 	require.Eventually(redirect, 5*time.Minute, time.Second)
+}
+
+type results struct {
+	protocol      string
+	viewers       float64
+	viewersPassed float64
+	score         float64
+}
+
+// This test will spawn multiple viewers at node catalyst-two and attempt streaming.
+// Any hiccups in playback or failure to connect will be captured and reported via MistLoadTest.
+func requireProtocolLoad(t *testing.T, c2 *catalystContainer) {
+	tests := map[string]struct {
+		url     string
+		viewers int
+		timeout int
+		score   float64
+	}{
+		"hls": {url: fmt.Sprintf("http://localhost:%s/hls/stream+foo/index.m3u8", c2.http), viewers: 5, timeout: 30, score: 0.8},
+	}
+
+	// Test each protocol defined in the tests map above
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := runProtocolLoadTest(t, name, tc.url, tc.viewers, tc.timeout)
+			glog.Infof("Protocol under test: %v, viewers: %v, viewers-passed: %v, score: %v", r.protocol, r.viewers, r.viewersPassed, r.score)
+			if r.score < tc.score {
+				t.Fatalf("Failed %s test with score: %v", r.protocol, r.score)
+			}
+
+		})
+	}
+}
+
+// Executes MistLoadTest for each protocol specified in tests table in requireProtocolLoad()
+func runProtocolLoadTest(t *testing.T, prot string, url string, viewers int, timeout int) *results {
+	dir := t.TempDir()
+	fmt.Printf("Testing %s url: %s with %d viewers using tmp dir (%s)\n", prot, url, viewers, dir)
+	cmdMistLoadTest := exec.Command("../../bin/./MistLoadTest", "-o", dir,
+		"-n", strconv.Itoa(viewers),
+		"-t", strconv.Itoa(timeout),
+		url)
+	out, err := cmdMistLoadTest.Output()
+	require.NoError(t, err)
+	if err != nil {
+		glog.Fatalf("Failed to start MistLoadTest: %s", err)
+	}
+	glog.Infof("MistLoadTest stdout: %s", out)
+
+	defer cmdMistLoadTest.Process.Kill()
+
+	return parseProtocolResults(t, dir, prot)
+}
+
+// Parses MistLoadTest's json output files to determine how many viewers
+// successfully connected and streamed from the specified catalyst node
+func parseProtocolResults(t *testing.T, testdir string, prot string) *results {
+	matches, err := filepath.Glob(testdir + "/" + "*" + strings.ToUpper(prot) + "*json")
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+
+	if len(matches) == 0 || len(matches) > 1 {
+		t.Fatalf("Expected only one results file but got %v files: %v", len(matches), matches)
+	}
+
+	content, err := ioutil.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("Error while opening results file: %s", err)
+	}
+	glog.Infof("Parsing file: %s", matches[0])
+
+	var payload map[string]interface{}
+	err = json.Unmarshal(content, &payload)
+	if err != nil {
+		t.Fatalf("Error during json.Unmarshal(): %s", err)
+	}
+
+	vtotal := float64(payload["viewers"].(float64))
+	vpass := float64(payload["viewers_passed"].(float64))
+	r := results{
+		protocol:      prot,
+		viewers:       vtotal,
+		viewersPassed: vpass,
+		score:         vpass / vtotal,
+	}
+
+	return &r
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -390,9 +390,17 @@ func requireProtocolLoad(t *testing.T, c2 *catalystContainer) {
 
 // Executes MistLoadTest for each protocol specified in tests table in requireProtocolLoad()
 func runProtocolLoadTest(t *testing.T, prot string, url string, viewers int, timeout int) *results {
+
+	//TODO: run Mist tester binaries in a dockerized container instead of this method to run on the host
+	tmpDir := t.TempDir()
+	cmd := exec.Command("../copy-mist-binaries.sh", tmpDir)
+	fmt.Printf("Running command and waiting for it to finish...")
+	_, err := cmd.Output()
+	fmt.Printf("Command finished with error: %v \n", err)
+
 	dir := t.TempDir()
 	fmt.Printf("Testing %s url: %s with %d viewers using tmp dir (%s)\n", prot, url, viewers, dir)
-	cmdMistLoadTest := exec.Command("../../bin/./MistLoadTest", "-o", dir,
+	cmdMistLoadTest := exec.Command(tmpDir+"/MistLoadTest", "-o", dir,
 		"-n", strconv.Itoa(viewers),
 		"-t", strconv.Itoa(timeout),
 		url)


### PR DESCRIPTION
Use MistLoadTest to spawn multiple clients for a specific protocol (e.g. HLS) as viewers at catalyst-two node. The test passes if every client is able to connect and stream successfully. The json files generated by MistLoadTest are parse to verify if streams passed or failed.