### PR TITLE
catalyst-node: populate MistUtilLoad with hostnames instead of ip-addr

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -93,7 +93,7 @@ func runClient(config catalystConfig) error {
 		membersMap := make(map[string]bool)
 
 		for _, member := range members {
-			memberHost := member.Addr.String()
+			memberHost := member.Name
 
 			// commented out as for now the load balancer does not return ports
 			//if member.Port != 0 {


### PR DESCRIPTION
Fix \#58