### PR TITLE
Add serf tags to enable bootstrap catalyst nodes

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -374,6 +374,8 @@ func parseSerfConfig(config *agent.Config, retryJoin *string, serfTags *string) 
 			if len(kv) == 2 {
 				k, v := kv[0], kv[1]
 				config.Tags[k] = v
+			} else {
+				glog.Fatalf("failed to parse serf tag, --serf-tag=k1=v1,k2=v2 format required: %s", t)
 			}
 		}
 	}

--- a/test/e2e/mist_config.go
+++ b/test/e2e/mist_config.go
@@ -2,9 +2,12 @@ package e2e
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 )
+
+const serfPort = "7373"
 
 type account struct {
 	Password string `json:"password"`
@@ -105,6 +108,7 @@ func defaultMistConfig() mistConfig {
 				{Connector: "TSSRT"},
 				{Connector: "WAV"},
 				{Connector: "WebRTC"},
+				{Connector: "livepeer-catalyst-node", RPCAddr: fmt.Sprintf("0.0.0.0:%s", serfPort)},
 			},
 			SessionInputMode:       "14",
 			SessionOutputMode:      "14",


### PR DESCRIPTION
Add support for tags while forming the Catalyst cluster. It will to set up bootstrap serf nodes which will not be used for Mist load balancing. Additionally, it allows to set up two separate Catalyst clusters using the same Serf cluster.

fix https://github.com/livepeer/livepeer-infra/issues/885