### PR TITLE
Use `commit` info to populate inside manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ WORKDIR	/build
 ADD	go.mod go.sum	./
 RUN	go mod download
 
-ADD Makefile manifest.yaml ./
+ADD	Makefile manifest.yaml ./
 ADD	cmd/downloader/ cmd/downloader/
-RUN make download
+RUN	make download
 
-ADD . .
+ADD	. .
 ARG	GIT_VERSION=unknown
+ENV	GIT_VERSION="${GIT_VERSION}"
 RUN	make livepeer-log livepeer-catalyst-node
 
 FROM	ubuntu:20.04

--- a/cmd/downloader/bucket/bucket.go
+++ b/cmd/downloader/bucket/bucket.go
@@ -57,6 +57,7 @@ func GetArtifactInfo(platform, architecture, release string, service *types.Serv
 	if err != nil {
 		glog.Fatal(err)
 	}
+	service.Strategy.Commit = buildInfo.Commit
 
 	var info = &types.ArtifactInfo{
 		Name:         service.Name,

--- a/cmd/downloader/github/github.go
+++ b/cmd/downloader/github/github.go
@@ -12,21 +12,9 @@ import (
 	glog "github.com/magicsong/color-glog"
 )
 
-type gitRefObject struct {
-	SHA  string `json:"sha"`
-	Type string `json:"type"`
-	URL  string `json:"url"`
-}
-
-type gitRefInfo struct {
-	Object gitRefObject `json:"object"`
-	URL    string       `json:"url"`
-	Ref    string       `json:"ref"`
-}
-
 // GetCommitSHA uses github api to find SHA for the tagged release
-func GetCommitSHA(project, tag string) *gitRefInfo {
-	var refInfo gitRefInfo
+func GetCommitSHA(project, tag string) *types.GitRefInfo {
+	var refInfo types.GitRefInfo
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/git/ref/tags/%s", project, tag)
 	resp, err := http.Get(apiURL)
 	if err != nil {

--- a/cmd/downloader/github/github_test.go
+++ b/cmd/downloader/github/github_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/livepeer/catalyst/cmd/downloader/types"
 )
 
+func TestCommitSHA(t *testing.T) {
+	projects := map[string][]string{
+		"livepeer/go-livepeer":   {"v0.5.33", "0b3c88f814dccca70a23022f4366eb8069955955"},
+		"livepeer/livepeer-data": {"v0.4.17", "4f6696fb83d15bb738d4ff824d47ad032d8d96f9"},
+	}
+	for project, tag := range projects {
+		refInfo := GetCommitSHA(project, tag[0])
+		if refInfo.Object.SHA != tag[1] {
+			t.Errorf("invalid commit SHA for project=%s tag=%s", project, tag)
+			t.Fail()
+		}
+	}
+}
+
 func TestTagInformation(t *testing.T) {
 	projects := []string{
 		"livepeer/stream-tester",

--- a/cmd/downloader/types/types.go
+++ b/cmd/downloader/types/types.go
@@ -35,6 +35,7 @@ type CliFlags struct {
 type DownloadStrategy struct {
 	Download string `yaml:"download,omitempty"`
 	Project  string `yaml:"project"`
+	Commit   string `yaml:"commit,omitempty"`
 }
 
 type Service struct {

--- a/cmd/downloader/types/types.go
+++ b/cmd/downloader/types/types.go
@@ -6,6 +6,7 @@ type TagInformation struct {
 	PreRelease bool   `json:"prerelease"`
 	TagName    string `json:"tag_name"`
 	Draft      bool   `json:"draft"`
+	Commit     string `json:"commit,omitempty"`
 }
 
 type BuildManifestInformation struct {

--- a/cmd/downloader/types/types.go
+++ b/cmd/downloader/types/types.go
@@ -1,5 +1,17 @@
 package types
 
+type gitRefObject struct {
+	SHA  string `json:"sha"`
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+type GitRefInfo struct {
+	Object gitRefObject `json:"object"`
+	URL    string       `json:"url"`
+	Ref    string       `json:"ref"`
+}
+
 type TagInformation struct {
 	Name       string `json:"name"`
 	ID         uint   `json:"id"`


### PR DESCRIPTION
This helps in negating docker cache; especially useful for bucket strategy builds.