### PR TITLE
manifest.go: Use `latest` as default release name when fetching github releases

### DIFF
--- a/cmd/downloader/manifest/manifest.go
+++ b/cmd/downloader/manifest/manifest.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/livepeer/catalyst/cmd/downloader/bucket"
 	"github.com/livepeer/catalyst/cmd/downloader/cli"
+	"github.com/livepeer/catalyst/cmd/downloader/constants"
 	"github.com/livepeer/catalyst/cmd/downloader/github"
 	"github.com/livepeer/catalyst/cmd/downloader/types"
 	"github.com/livepeer/catalyst/cmd/downloader/utils"
@@ -45,6 +46,7 @@ func Run(buildFlags types.BuildFlags) {
 		if service.Strategy.Download == "bucket" {
 			projectInfo = bucket.GetArtifactInfo(platform, architecture, manifest.Release, service)
 		} else if service.Strategy.Download == "github" {
+			service.Release = constants.LatestTagReleaseName
 			projectInfo = github.GetArtifactInfo(platform, architecture, manifest.Release, service)
 			service.Release = projectInfo.Version
 		}


### PR DESCRIPTION
This should resolve empty webhook triggers which don't pick changes to upstream project releases.