### PR TITLE
e2e_test: set stream-interruption test to fail correctly

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -46,6 +46,7 @@ box:
         darwin-arm64: livepeer-mistserver-darwin-arm64.tar.gz
         linux-amd64: livepeer-mistserver-linux-amd64.tar.gz
         linux-arm64: livepeer-mistserver-linux-arm64.tar.gz
+        #TODO: automate mist builds
     - name: www
       strategy:
         download: github

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -145,18 +145,7 @@ func TestStreamInterruption(t *testing.T) {
 	defer p2.Kill()
 
 	// Start load test to simulate multiple viewers at catalyst-two node
-	// TODO: This test will succeed until issue #65 (https://github.com/DDVTECH/mistserver/issues/65)
-	//       is resolved. The current goal of this test is to flag cases when #65 reproduces. Once the
-	//       issue is resolved, the expected passing conditions will be updated below.
-	viewers := 5
-	timeout := 30
-	r := runProtocolLoadTest(t, "hls", fmt.Sprintf("http://localhost:%s/hls/stream+foo/index.m3u8", c2.http), viewers, timeout)
-	glog.Infof("Protocol under test: %v, viewers: %v, viewers-passed: %v, score: %v", r.protocol, r.viewers, r.viewersPassed, r.score)
-	if r.score == 0 {
-		glog.Infof("Failed %s test with score %v but ignoring failure", r.protocol, r.score)
-	} else {
-		t.Fatalf("Expected to fail but passed %s test with score: %v", r.protocol, r.score)
-	}
+	requireProtocolLoad(t, c2)
 }
 
 func TestBootstrapNode(t *testing.T) {
@@ -421,7 +410,7 @@ func requireProtocolLoad(t *testing.T, c2 *catalystContainer) {
 		timeout int
 		score   float64
 	}{
-		"hls": {url: fmt.Sprintf("http://localhost:%s/hls/stream+foo/index.m3u8", c2.http), viewers: 5, timeout: 30, score: 0.8},
+		"hls": {url: fmt.Sprintf("http://localhost:%s/hls/stream+foo/index.m3u8", c2.http), viewers: 5, timeout: 30, score: 0.95},
 	}
 
 	// Test each protocol defined in the tests map above


### PR DESCRIPTION
In #86, we added stream interruption test i.e. verify playback still recovers
after ingest stream is killed and restarted. However, we set it to forcefully
pass even with failures - this was temporary until we root-caused the issue.
With #65 now resolved, this stream interruption test can be correctly set to
fail if playback is not able to recover correctly during an ingest stream
interruption.

Fix \#97