### PR TITLE
mapic: hack alert! get livepeer-mist-api-connector from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ARG	GIT_VERSION=unknown
 ENV	GIT_VERSION="${GIT_VERSION}"
 RUN	make livepeer-log livepeer-catalyst-node
 
+FROM livepeer/streamtester:v0.12.5-16-g9e1b00c as mapic
 FROM	ubuntu:20.04
 
 LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"
@@ -24,6 +25,7 @@ RUN	apt update && apt install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=gobuild	/build/bin/	/usr/bin/
+COPY --from=mapic /root/mist-api-connector /usr/bin/livepeer-mist-api-connector
 
 EXPOSE	1935	4242	8080	8889/udp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG	GIT_VERSION=unknown
 ENV	GIT_VERSION="${GIT_VERSION}"
 RUN	make livepeer-log livepeer-catalyst-node
 
-FROM livepeer/streamtester:v0.12.5-16-g9e1b00c as mapic
+FROM	livepeer/mist-api-connector:v0.12.5-18-g30e54c1 as mapic
 FROM	ubuntu:20.04
 
 LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"


### PR DESCRIPTION
Unblocking @gioelecerati but we really need to get branch-based bucket builds for all of the projects