### PR TITLE
S3 output support: add catalyst-uploader binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ manifest:
 
 .PHONY: dev
 dev:
-	if [ $$(uname) == "Darwin" ]; then \
+	if [ $$(uname) = "Darwin" ]; then \
 		if [ ! -d "/Volumes/RAMDisk/" ]; then \
 			disk=$$(hdiutil attach -nomount ram://4194304) \
 			&& sleep 3 \
@@ -128,6 +128,7 @@ dev:
 		&& rm -rf /Volumes/RAMDisk/mist \
 		&& export TMP=/Volumes/RAMDisk; \
 	fi \
+	&& export PATH=$$PATH:$$(pwd)/bin \
 	&& stat $(HOME)/.config/livepeer/mistserver.dev.conf || cp ./config/mistserver.dev.conf $(HOME)/.config/livepeer/mistserver.dev.conf \
 	&& ./bin/MistController -c $(HOME)/.config/livepeer/mistserver.dev.conf
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -30,9 +30,9 @@ box:
       strategy:
         download: github
         project: livepeer/catalyst-uploader
-        commit: 1fa7c2075f080dd6b5e30a000e58d21ce5cbb776
+        commit: de92fc87aefe91f134ac465a93608d92431abddf
       binary: livepeer-catalyst-uploader
-      release: v0.0.7
+      release: v0.0.9
     - name: livepeer
       strategy:
         download: github
@@ -45,7 +45,7 @@ box:
       strategy:
         download: bucket
         project: mistserver
-        commit: 5f695e47bfa8f42dce7bd25c6d78852cc4f300e9
+        commit: 5d1b02f3ce2957b462e0fa5b0b203cd896eacd3f
       release: catalyst
       skipGpg: true
       srcFilenames:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -26,6 +26,13 @@ box:
         commit: 31300bfcbae7f20305e45222303067e694ae2268
       binary: livepeer-mist-api-connector
       release: v0.12.19
+    - name: catalyst-uploader
+      strategy:
+        download: github
+        project: livepeer/catalyst-uploader
+        commit: 4252847669ebbec888a8a28bed1b82e80176ae23
+      binary: livepeer-catalyst-uploader
+      release: v0.0.5
     - name: livepeer
       strategy:
         download: github
@@ -38,7 +45,7 @@ box:
       strategy:
         download: bucket
         project: mistserver
-        commit: 3b2cb3abaf2c107649133608cb07806e4eecdba2
+        commit: 5f695e47bfa8f42dce7bd25c6d78852cc4f300e9
       release: catalyst
       skipGpg: true
       srcFilenames:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -30,9 +30,9 @@ box:
       strategy:
         download: github
         project: livepeer/catalyst-uploader
-        commit: 4252847669ebbec888a8a28bed1b82e80176ae23
+        commit: 1fa7c2075f080dd6b5e30a000e58d21ce5cbb776
       binary: livepeer-catalyst-uploader
-      release: v0.0.5
+      release: v0.0.7
     - name: livepeer
       strategy:
         download: github

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -30,9 +30,9 @@ box:
       strategy:
         download: github
         project: livepeer/catalyst-uploader
-        commit: de92fc87aefe91f134ac465a93608d92431abddf
+        commit: 6eef492c7cb703e37bbe8f875350a2de75bb4503
       binary: livepeer-catalyst-uploader
-      release: v0.0.9
+      release: v0.1.1
     - name: livepeer
       strategy:
         download: github


### PR DESCRIPTION
Added `bin/` dir to PATH for `dev` target, because otherwise Mist can't find `livepeer-catalyst-uploader` binary. Should we update binary discovery in Mist?