### PR TITLE
catalyst-node: Add `redirectPrefixes` support when querying mist

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: reviewdog/action-misspell@v1
 
       - name: Run tests with coverage
-        run: go test ./... --short --race --covermode=atomic --coverprofile=coverage.out
+        run: go test ./... --short --covermode=atomic --coverprofile=coverage.out
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.out
-          name: catalyst
+          name: ${{ github.event.repository.name }}
           verbose: true

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -305,7 +305,7 @@ func main() {
 	}
 
 	cliFlags.RedirectPrefixes = strings.Split(*prefixes, ",")
-	glog.Infof("found redirectPrefixes=%v", cliFlags.RedirectPrefixes)
+	glog.V(4).Infof("found redirectPrefixes=%v", cliFlags.RedirectPrefixes)
 
 	parseSerfConfig(&serfConfig, retryJoin, serfTags)
 

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -305,6 +305,7 @@ func main() {
 	}
 
 	cliFlags.RedirectPrefixes = strings.Split(*prefixes, ",")
+	glog.Infof("found redirectPrefixes=%v", cliFlags.RedirectPrefixes)
 
 	parseSerfConfig(&serfConfig, retryJoin, serfTags)
 
@@ -443,7 +444,7 @@ func redirectHlsHandler(redirectPrefixes []string) http.Handler {
 		lat := r.Header.Get("X-Latitude")
 		lon := r.Header.Get("X-Longitude")
 
-		var nodeAddr string
+		var nodeAddr, validPrefix string
 		var err error
 
 		for _, prefix := range redirectPrefixes {
@@ -453,6 +454,7 @@ func redirectHlsHandler(redirectPrefixes []string) http.Handler {
 				continue
 			}
 			if nodeAddr != "" {
+				validPrefix = prefix + "+"
 				err = nil
 				break
 			}
@@ -464,7 +466,7 @@ func redirectHlsHandler(redirectPrefixes []string) http.Handler {
 			return
 		}
 
-		rURL := fmt.Sprintf("%s://%s/hls/%s/index.m3u8", protocol(r), nodeAddr, playbackID)
+		rURL := fmt.Sprintf("%s://%s/hls/%s%s/index.m3u8", protocol(r), nodeAddr, validPrefix, playbackID)
 		http.Redirect(w, r, rURL, http.StatusFound)
 	})
 }

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -308,7 +308,7 @@ func main() {
 
 	parseSerfConfig(&serfConfig, retryJoin, serfTags)
 
-	go startCatalystWebServer(cliFlags.HTTPAddress)
+	go startCatalystWebServer(cliFlags.HTTPAddress, cliFlags.RedirectPrefixes)
 
 	config.serfTags = serfConfig.Tags
 
@@ -325,7 +325,7 @@ func main() {
 		// eli note: i put this in a loop in case client boots before server.
 		// doesn't seem to happen in practice.
 		for {
-			err := runClient(config)
+			err := runClient(*config)
 			if err != nil {
 				glog.Errorf("Error starting client: %v", err)
 			}

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -459,7 +459,7 @@ func redirectHlsHandler(redirectPrefixes []string) http.Handler {
 		}
 
 		if nodeAddr == "" || err != nil {
-			glog.Errorf("error finding origin server playbackID=%s error=%s prefix=%s", playbackID, err)
+			glog.Errorf("error finding origin server playbackID=%s error=%s", playbackID, err)
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -470,11 +470,16 @@ func redirectHlsHandler(redirectPrefixes []string) http.Handler {
 }
 
 func parsePlaybackID(path string) (string, bool) {
-	r := regexp.MustCompile("^/hls/([a-zA-Z0-9_\\-+]+)/index.m3u8$")
+	r := regexp.MustCompile("^/hls/([\\w+-]+)/index.m3u8$")
 	m := r.FindStringSubmatch(path)
 	if len(m) < 2 {
 		return "", false
 	}
+	// Incoming requests might come with some prefix attached to the
+	// playback ID. We try to drop that here by splitting at `+` and
+	// picking the last piece. For eg.
+	// incoming path = '/hls/video+4712oox4msvs9qsf/index.m3u8'
+	// playbackID = '4712oox4msvs9qsf'
 	slice := strings.Split(m[1], "+")
 	return slice[len(slice)-1], true
 }

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -467,6 +467,7 @@ func redirectHlsHandler(redirectPrefixes []string) http.Handler {
 		}
 
 		rURL := fmt.Sprintf("%s://%s/hls/%s%s/index.m3u8", protocol(r), nodeAddr, validPrefix, playbackID)
+		glog.V(6).Infof("generated redirect url=%s", rURL)
 		http.Redirect(w, r, rURL, http.StatusFound)
 	})
 }

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -14,7 +14,7 @@ const (
 	playbackID      = "abc_XYZ-123"
 )
 
-var prefixes = []string{"video", "videorec"}
+var prefixes = [...]string{"video"}
 
 func TestRedirectHandler_Correct(t *testing.T) {
 	defaultFunc := getClosestNode
@@ -24,13 +24,13 @@ func TestRedirectHandler_Correct(t *testing.T) {
 	requireReq(t, fmt.Sprintf("/hls/%s/index.m3u8", playbackID)).
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", fmt.Sprintf("http://%s/hls/%s/index.m3u8", closestNodeAddr, playbackID))
+		hasHeader("Location", fmt.Sprintf("http://%s/hls/%s+%s/index.m3u8", closestNodeAddr, prefixes[0], playbackID))
 
 	requireReq(t, fmt.Sprintf("/hls/%s/index.m3u8", playbackID)).
 		withHeader("X-Forwarded-Proto", "https").
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", fmt.Sprintf("https://%s/hls/%s/index.m3u8", closestNodeAddr, playbackID))
+		hasHeader("Location", fmt.Sprintf("https://%s/hls/%s+%s/index.m3u8", closestNodeAddr, prefixes[0], playbackID))
 }
 
 func TestRedirectHandler_InvalidPath(t *testing.T) {
@@ -68,7 +68,7 @@ func (hr httpReq) withHeader(key, value string) httpReq {
 
 func (hr httpReq) result() httpCheck {
 	rr := httptest.NewRecorder()
-	redirectHlsHandler(prefixes).ServeHTTP(rr, hr.Request)
+	redirectHlsHandler(prefixes[:]).ServeHTTP(rr, hr.Request)
 	return httpCheck{hr.T, rr}
 }
 

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -18,7 +18,7 @@ var prefixes = []string{"video", "videorec"}
 
 func TestRedirectHandler_Correct(t *testing.T) {
 	defaultFunc := getClosestNode
-	getClosestNode = func(string, string, string, []string) (string, error) { return closestNodeAddr, nil }
+	getClosestNode = func(string, string, string, string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
 
 	requireReq(t, fmt.Sprintf("/hls/%s/index.m3u8", playbackID)).

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,25 +13,70 @@ import (
 const (
 	closestNodeAddr = "someurl.com"
 	playbackID      = "abc_XYZ-123"
+	pathTemplate    = "/hls/%s/index.m3u8"
 )
 
-var prefixes = [...]string{"video"}
+var prefixes = [...]string{"video", "videorec", "stream", "playback"}
+
+func randomPlaybackID(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+
+	res := make([]byte, length)
+	for i := 0; i < length; i++ {
+		res[i] = charset[rand.Intn(length)]
+	}
+	return string(res)
+}
+
+func TestPlaybackIDParserWithPrefix(t *testing.T) {
+	for i := 0; i < rand.Int()%16+1; i++ {
+		id := randomPlaybackID(rand.Int()%24 + 1)
+		path := fmt.Sprintf("/hls/%s+%s/index.m3u8", prefixes[rand.Intn(len(prefixes))], id)
+		playbackID, parsed := parsePlaybackID(path)
+		if !parsed {
+			t.Fail()
+		}
+		require.Equal(t, id, playbackID)
+	}
+}
+
+func TestPlaybackIDParserWithoutPrefix(t *testing.T) {
+	for i := 0; i < rand.Int()%16+1; i++ {
+		id := randomPlaybackID(rand.Int()%24 + 1)
+		path := fmt.Sprintf("/hls/%s/index.m3u8", id)
+		playbackID, parsed := parsePlaybackID(path)
+		if !parsed {
+			t.Fail()
+		}
+		require.Equal(t, id, playbackID)
+	}
+}
+
+func getURLs(proto, host string) []string {
+	var urls []string
+	for _, prefix := range prefixes {
+		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/index.m3u8", proto, host, prefix, playbackID))
+	}
+	return urls
+}
 
 func TestRedirectHandler_Correct(t *testing.T) {
 	defaultFunc := getClosestNode
 	getClosestNode = func(string, string, string, string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
 
-	requireReq(t, fmt.Sprintf("/hls/%s/index.m3u8", playbackID)).
+	path := fmt.Sprintf("/hls/%s/index.m3u8", playbackID)
+
+	requireReq(t, path).
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", fmt.Sprintf("http://%s/hls/%s+%s/index.m3u8", closestNodeAddr, prefixes[0], playbackID))
+		hasHeader("Location", getURLs("http", closestNodeAddr)...)
 
-	requireReq(t, fmt.Sprintf("/hls/%s/index.m3u8", playbackID)).
+	requireReq(t, path).
 		withHeader("X-Forwarded-Proto", "https").
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", fmt.Sprintf("https://%s/hls/%s+%s/index.m3u8", closestNodeAddr, prefixes[0], playbackID))
+		hasHeader("Location", getURLs("https", closestNodeAddr)...)
 }
 
 func TestRedirectHandler_InvalidPath(t *testing.T) {
@@ -77,7 +123,16 @@ func (hc httpCheck) hasStatus(code int) httpCheck {
 	return hc
 }
 
-func (hc httpCheck) hasHeader(key, value string) httpCheck {
-	require.Equal(hc, value, hc.Header().Get(key))
+func (hc httpCheck) hasHeader(key string, values ...string) httpCheck {
+	var success = false
+	header := hc.Header().Get(key)
+	for _, value := range values {
+		fmt.Printf("%s\t%s\n", header, value)
+		if header == value {
+			success = true
+			break
+		}
+	}
+	require.True(hc, success)
 	return hc
 }

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -14,9 +14,11 @@ const (
 	playbackID      = "abc_XYZ-123"
 )
 
+var prefixes = []string{"video", "videorec"}
+
 func TestRedirectHandler_Correct(t *testing.T) {
 	defaultFunc := getClosestNode
-	getClosestNode = func(string, string, string) (string, error) { return closestNodeAddr, nil }
+	getClosestNode = func(string, string, string, []string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
 
 	requireReq(t, fmt.Sprintf("/hls/%s/index.m3u8", playbackID)).
@@ -66,7 +68,7 @@ func (hr httpReq) withHeader(key, value string) httpReq {
 
 func (hr httpReq) result() httpCheck {
 	rr := httptest.NewRecorder()
-	redirectHlsHandler().ServeHTTP(rr, hr.Request)
+	redirectHlsHandler(prefixes).ServeHTTP(rr, hr.Request)
 	return httpCheck{hr.T, rr}
 }
 

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -127,7 +127,6 @@ func (hc httpCheck) hasHeader(key string, values ...string) httpCheck {
 	var success = false
 	header := hc.Header().Get(key)
 	for _, value := range values {
-		fmt.Printf("%s\t%s\n", header, value)
 		if header == value {
 			success = true
 			break

--- a/config/catalyst-one.json
+++ b/config/catalyst-one.json
@@ -20,8 +20,8 @@
     "defaultStream": null,
     "limits": null,
     "location": {
-      "lat": 0.0000000000,
-      "lon": 0.0000000000,
+      "lat": 0.0,
+      "lon": 0.0,
       "name": ""
     },
     "prometheus": "koekjes",
@@ -92,7 +92,8 @@
       {
         "connector": "livepeer-catalyst-node",
         "retry-join": "catalyst-two",
-        "rpc-addr": "0.0.0.0:7373"
+        "rpc-addr": "0.0.0.0:7373",
+        "redirect-prefixes": "stream"
       }
     ],
     "serverid": null,

--- a/config/catalyst-two.json
+++ b/config/catalyst-two.json
@@ -20,8 +20,8 @@
     "defaultStream": null,
     "limits": null,
     "location": {
-      "lat": 0.0000000000,
-      "lon": 0.0000000000,
+      "lat": 0.0,
+      "lon": 0.0,
       "name": ""
     },
     "prometheus": "koekjes",
@@ -91,7 +91,8 @@
       },
       {
         "connector": "livepeer-catalyst-node",
-        "retry-join": "catalyst-one"
+        "retry-join": "catalyst-one",
+        "redirect-prefixes": "stream"
       }
     ],
     "serverid": null,

--- a/test/e2e/mist_config.go
+++ b/test/e2e/mist_config.go
@@ -19,9 +19,10 @@ type bandwidth struct {
 }
 
 type protocol struct {
-	Connector string `json:"connector"`
-	RetryJoin string `json:"retry-join,omitempty"`
-	RPCAddr   string `json:"rpc-addr,omitempty"`
+	Connector        string `json:"connector"`
+	RetryJoin        string `json:"retry-join,omitempty"`
+	RPCAddr          string `json:"rpc-addr,omitempty"`
+	RedirectPrefixes string `json:"redirect-prefixes,omitempty"`
 }
 
 type config struct {
@@ -108,7 +109,7 @@ func defaultMistConfig() mistConfig {
 				{Connector: "TSSRT"},
 				{Connector: "WAV"},
 				{Connector: "WebRTC"},
-				{Connector: "livepeer-catalyst-node", RPCAddr: fmt.Sprintf("0.0.0.0:%s", serfPort)},
+				{Connector: "livepeer-catalyst-node", RPCAddr: fmt.Sprintf("0.0.0.0:%s", serfPort), RedirectPrefixes: "stream"},
 			},
 			SessionInputMode:       "14",
 			SessionOutputMode:      "14",


### PR DESCRIPTION
Fixes #95 and livepeer/livepeer-infra#894