### PR TITLE
catalyst-node: add support for /json_prefix+stream.js urls, 404 handling

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -434,6 +434,7 @@ var getClosestNode = queryMistForClosestNode
 // return the best node available for a given stream. will return any node if nobody has the stream.
 func getBestNode(redirectPrefixes []string, playbackID, lat, lon string) (string, string, error) {
 	var nodeAddr, fullPlaybackID, fallbackAddr string
+	var mu sync.Mutex
 	var err error
 	var waitGroup sync.WaitGroup
 
@@ -441,9 +442,11 @@ func getBestNode(redirectPrefixes []string, playbackID, lat, lon string) (string
 		waitGroup.Add(1)
 		go func(prefix string) {
 			addr, e := getClosestNode(playbackID, lat, lon, prefix)
+			mu.Lock()
+			defer mu.Unlock()
 			if e != nil {
-				err := e
-				glog.V(8).Infof("error finding origin server playbackID=%s prefix=%s error=%s", playbackID, prefix, err)
+				err = e
+				glog.V(8).Infof("error finding origin server playbackID=%s prefix=%s error=%s", playbackID, prefix, e)
 				// If we didn't find a stream but we did find a server, keep that so we can use it to handle a 404
 				if addr != "" {
 					fallbackAddr = addr

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -498,17 +498,17 @@ func redirectHandler(redirectPrefixes []string) http.Handler {
 	})
 }
 
+// Incoming requests might come with some prefix attached to the
+// playback ID. We try to drop that here by splitting at `+` and
+// picking the last piece. For eg.
+// incoming path = '/hls/video+4712oox4msvs9qsf/index.m3u8'
+// playbackID = '4712oox4msvs9qsf'
 func parsePlaybackIDHLS(path string) (string, string, bool) {
 	r := regexp.MustCompile(`^/hls/([\w+-]+)/(.*index.m3u8.*)$`)
 	m := r.FindStringSubmatch(path)
 	if len(m) < 3 {
 		return "", "", false
 	}
-	// Incoming requests might come with some prefix attached to the
-	// playback ID. We try to drop that here by splitting at `+` and
-	// picking the last piece. For eg.
-	// incoming path = '/hls/video+4712oox4msvs9qsf/index.m3u8'
-	// playbackID = '4712oox4msvs9qsf'
 	slice := strings.Split(m[1], "+")
 	pathTmpl := "/hls/%s/" + m[2]
 	return slice[len(slice)-1], pathTmpl, true
@@ -520,11 +520,6 @@ func parsePlaybackIDJS(path string) (string, string, bool) {
 	if len(m) < 2 {
 		return "", "", false
 	}
-	// Incoming requests might come with some prefix attached to the
-	// playback ID. We try to drop that here by splitting at `+` and
-	// picking the last piece. For eg.
-	// incoming path = '/hls/video+4712oox4msvs9qsf/index.m3u8'
-	// playbackID = '4712oox4msvs9qsf'
 	slice := strings.Split(m[1], "+")
 	return slice[len(slice)-1], "/json_%s.js", true
 }

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -479,7 +479,7 @@ func redirectHandler(redirectPrefixes []string) http.Handler {
 }
 
 func parsePlaybackIDHLS(path string) (string, string, bool) {
-	r := regexp.MustCompile("^/hls/([\\w+-]+)/(.*index.m3u8.*)$")
+	r := regexp.MustCompile(`^/hls/([\w+-]+)/(.*index.m3u8.*)$`)
 	m := r.FindStringSubmatch(path)
 	if len(m) < 3 {
 		return "", "", false
@@ -495,7 +495,7 @@ func parsePlaybackIDHLS(path string) (string, string, bool) {
 }
 
 func parsePlaybackIDJS(path string) (string, string, bool) {
-	r := regexp.MustCompile("^/json_([\\w+-]+).js$")
+	r := regexp.MustCompile(`^/json_([\w+-]+).js$`)
 	m := r.FindStringSubmatch(path)
 	if len(m) < 2 {
 		return "", "", false

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -65,7 +65,7 @@ func TestPlaybackIDParserWithoutPrefix(t *testing.T) {
 	}
 }
 
-func getURLs(proto, host string) []string {
+func getHLSURLs(proto, host string) []string {
 	var urls []string
 	for _, prefix := range prefixes {
 		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/index.m3u8", proto, host, prefix, playbackID))
@@ -73,7 +73,7 @@ func getURLs(proto, host string) []string {
 	return urls
 }
 
-func getURLsWithSeg(proto, host, seg string) []string {
+func getHLSURLsWithSeg(proto, host, seg string) []string {
 	var urls []string
 	for _, prefix := range prefixes {
 		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/%s/index.m3u8", proto, host, prefix, playbackID, seg))
@@ -81,7 +81,7 @@ func getURLsWithSeg(proto, host, seg string) []string {
 	return urls
 }
 
-func TestRedirectHandler_Correct(t *testing.T) {
+func TestRedirectHandlerHLS_Correct(t *testing.T) {
 	defaultFunc := getClosestNode
 	getClosestNode = func(string, string, string, string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
@@ -91,16 +91,16 @@ func TestRedirectHandler_Correct(t *testing.T) {
 	requireReq(t, path).
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", getURLs("http", closestNodeAddr)...)
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr)...)
 
 	requireReq(t, path).
 		withHeader("X-Forwarded-Proto", "https").
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", getURLs("https", closestNodeAddr)...)
+		hasHeader("Location", getHLSURLs("https", closestNodeAddr)...)
 }
 
-func TestRedirectHandler_SegmentInPath(t *testing.T) {
+func TestRedirectHandlerHLS_SegmentInPath(t *testing.T) {
 	defaultFunc := getClosestNode
 	getClosestNode = func(string, string, string, string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
@@ -112,10 +112,10 @@ func TestRedirectHandler_SegmentInPath(t *testing.T) {
 	requireReq(t, path).
 		result().
 		hasStatus(http.StatusFound).
-		hasHeader("Location", getURLsWithSeg("http", closestNodeAddr, seg)...)
+		hasHeader("Location", getHLSURLsWithSeg("http", closestNodeAddr, seg)...)
 }
 
-func TestRedirectHandler_InvalidPath(t *testing.T) {
+func TestRedirectHandlerHLS_InvalidPath(t *testing.T) {
 	requireReq(t, "/hls").result().hasStatus(http.StatusNotFound)
 	requireReq(t, "/hls").result().hasStatus(http.StatusNotFound)
 	requireReq(t, "/hls/").result().hasStatus(http.StatusNotFound)


### PR DESCRIPTION
I'm kind of unhappy with the messiness of this; in particular returning both a URL and an error from the `queryMistForClosestNode()` function is kind of smelly. I at least tried to thoroughly-comment all the confusing cases of "we didn't find the stream but return the server anyway" kind of thing.