### PR TITLE
Add auto push of live streams, add MinIO S3 dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ go1.17 is recommended because building with < 1.17 (specifically 1.16) can resul
 From there:
 
 ```
-# boots up Postgres and RabbitMQ dependencies
+# boots up Postgres, RabbitMQ and MinIO S3 dependencies
 make docker-compose
 
 # downloads or builds services as appropriate
@@ -17,9 +17,10 @@ make
 make dev
 ```
 
-You should then have a web interface running at
-[http://localhost:3004](http://localhost:3004) and a Mist interface at
-[http://localhost:4242](http://localhost:4242).
+After that, you should have a few web interfaces running:
+- Livepeer Studio at [http://localhost:3012](http://localhost:3012)
+- Mist at [http://localhost:4242](http://localhost:4242).
+- MinIO S3 at [http://localhost:9000](http://localhost:9000)
 
 ## Credentials/secrets
 
@@ -36,6 +37,13 @@ Mist credentials:
 username: test
 password: test
 ```
+
+MinIO S3 credentials:
+
+````
+username: minioadmin
+password: minioadmin
+````
 
 ## Manifest
 

--- a/config/minio.sh
+++ b/config/minio.sh
@@ -4,7 +4,13 @@ minio server /data --console-address ":9001"&
 sleep 5
 # download management utility
 if [[ ! -e "/data/mc" ]]; then
-  curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o /data/mc
+  case $(uname -m) in
+    x86_64) ARCH="amd64" ;;
+    arm64)  ARCH="arm64" ;;
+    *) ARCH="$(uname -m)" ;;
+  esac
+  OSARCH=$(uname|tr [:upper:] [:lower:])-$ARCH
+  curl https://dl.min.io/client/mc/release/$OSARCH/mc --create-dirs -o /data/mc
   chmod +x /data/mc
 else
   # wait a bit until the server is online

--- a/config/minio.sh
+++ b/config/minio.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# start minio server
+minio server /data --console-address ":9001"&
+sleep 5
+# download management utility
+if [[ ! -e "/data/mc" ]]; then
+  curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o /data/mc
+  chmod +x /data/mc
+else
+  # wait a bit until the server is online
+  sleep 5
+fi
+cd /data
+# set credentials
+./mc alias set local http://localhost:9000/ minioadmin minioadmin
+# create test bucket
+./mc mb test_bucket
+# create service account
+./mc admin user svcacct add                    \
+     --access-key "xZ1cZfALGp32hxpP"          \
+     --secret-key "Vw52yWwNnwabX7pHcLvxXddKlfoZ9L59"  \
+   local minioadmin
+
+sleep infinity

--- a/config/minio.sh
+++ b/config/minio.sh
@@ -7,7 +7,7 @@ if [[ ! -e "/data/mc" ]]; then
   case $(uname -m) in
     x86_64) ARCH="amd64" ;;
     arm64)  ARCH="arm64" ;;
-    *) ARCH="$(uname -m)" ;;
+    *) ARCH=$(uname -m) ;;
   esac
   OSARCH=$(uname|tr [:upper:] [:lower:])-$ARCH
   curl https://dl.min.io/client/mc/release/$OSARCH/mc --create-dirs -o /data/mc

--- a/config/mistserver.dev.conf
+++ b/config/mistserver.dev.conf
@@ -4,7 +4,12 @@
       "password": "098f6bcd4621d373cade4e832627b4f6"
     }
   },
-  "autopushes": null,
+  "autopushes": [
+                    [
+                      "video+",
+                      "s3+http://xZ1cZfALGp32hxpP:Vw52yWwNnwabX7pHcLvxXddKlfoZ9L59@localhost:9000/test_bucket/$stream/playlist.m3u8"
+                    ]
+  ],
   "bandwidth": {
     "exceptions": [],
     "limit": 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,15 @@
 
 version: "3.2"
 services:
+  minio:
+    image: quay.io/minio/minio
+    ports:
+      - 9000:9000
+      - 9001:9001
+    volumes:
+      - ./.docker/minio/data:/data
+      - ./config/minio.sh:/minio.sh
+    entrypoint: bash -c /minio.sh
   postgres:
     image: postgres
     container_name: box-postgres


### PR DESCRIPTION
**Changes:**
* Added Mist dev configuration to push new live streams (with names starting with `video+`) to S3.
* Added MinIO docker container to make it easier to work with S3 storage locally

Related [issue](https://github.com/livepeer/go-livepeer/issues/2506). 

**In progress:**
- test with Catalyst Studio, getting errors trying to run it locally

**Need help with:**
- updating `autopush` section of Mist config for production, including adding S3 secrets