### PR TITLE
bucket.go: Use commit hash provided in manifest over current value

### DIFF
--- a/cmd/downloader/bucket/bucket.go
+++ b/cmd/downloader/bucket/bucket.go
@@ -57,13 +57,17 @@ func GetArtifactInfo(platform, architecture, release string, service *types.Serv
 	if err != nil {
 		glog.Fatal(err)
 	}
+	commit := service.Strategy.Commit
+	if commit == "" {
+		commit = GetArtifactVersion(*buildInfo)
+	}
 	service.Strategy.Commit = buildInfo.Commit
 
 	var info = &types.ArtifactInfo{
 		Name:         service.Name,
 		Platform:     platform,
 		Architecture: architecture,
-		Version:      GetArtifactVersion(*buildInfo),
+		Version:      commit,
 	}
 
 	extension := utils.PlatformExt(platform)
@@ -97,5 +101,6 @@ func GetArtifactInfo(platform, architecture, release string, service *types.Serv
 		info.SignatureFileName = fmt.Sprintf("%s.%s", info.ArchiveFileName, constants.SignatureFileExtension)
 		info.SignatureURL = GenerateArtifactURL(project, info.Version, info.SignatureFileName)
 	}
+
 	return info
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/serf v0.9.8
 	github.com/magicsong/color-glog v0.0.1
 	github.com/mitchellh/cli v1.1.4
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/stretchr/testify v1.7.2
 	github.com/testcontainers/testcontainers-go v0.13.1-0.20220712105725-8e65673ca167
@@ -57,7 +58,6 @@ require (
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/miekg/dns v1.1.41 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/moby/sys/mount v0.3.3 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect


### PR DESCRIPTION
This would allow for finer version control on released binaries. Currently, the downloads are always done for most 'recent' commit available for a branch in `bucket` strategy. This led to and old issue #110 

With the change here, the commit SHA (if present in `manifest.yaml`) would be the default value to download.