### PR TITLE
catalyst-node: changes for production release

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -507,7 +507,7 @@ func streamSourceHandler() http.Handler {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			glog.Errorf("error handling STREAM_SOURCE body=%s", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("push://"))
 			return
 		}
 		streamName := string(b)
@@ -515,7 +515,7 @@ func streamSourceHandler() http.Handler {
 		source, err := getStreamSource(streamName)
 		if err != nil {
 			glog.Errorf("error finding STREAM_SOURCE: %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("push://"))
 			return
 		}
 		glog.V(7).Infof("replying to Mist STREAM_SOURCE request=%s response=%s", streamName, source)

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -284,6 +284,7 @@ func main() {
 	// Serf commands passed straight through to the agent
 	serfConfig := agent.Config{}
 	fs.StringVar(&serfConfig.BindAddr, "bind", "0.0.0.0:9935", "Address to bind network listeners to. To use an IPv6 address, specify [::1] or [::1]:7946.")
+	fs.StringVar(&serfConfig.AdvertiseAddr, "advertise", "0.0.0.0", "Address to advertise to the other cluster members")
 	fs.StringVar(&serfConfig.RPCAddr, "rpc-addr", "127.0.0.1:7373", "Address to bind the RPC listener.")
 	retryJoin := fs.String("retry-join", "", "An agent to join with. This flag be specified multiple times. Does not exit on failure like -join, used to retry until success.")
 	fs.StringVar(&serfConfig.EncryptKey, "encrypt", "", "Key for encrypting network traffic within Serf. Must be a base64-encoded 32-byte key.")

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -53,6 +53,8 @@ type catalystNodeCliFlags struct {
 	NodeHost         string
 }
 
+var mediaFilter = map[string]string{"node": "media"}
+
 func runClient(config catalystConfig) error {
 	client, err := connectSerfAgent(config.serfRPCAddress, config.serfRPCAuthKey)
 
@@ -98,7 +100,7 @@ func runClient(config catalystConfig) error {
 		<-inbox
 		glog.V(5).Infof("got event: %v", event)
 
-		members, err := client.MembersFiltered(config.serfTags, ".*", ".*")
+		members, err := client.MembersFiltered(mediaFilter, ".*", ".*")
 
 		if err != nil {
 			glog.Errorf("Error getting serf, will retry: %v\n", err)

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -497,7 +497,7 @@ func redirectHandler(redirectPrefixes []string, nodeHost string) http.Handler {
 
 		rPath := fmt.Sprintf(pathTmpl, fullPlaybackID)
 		rURL := fmt.Sprintf("%s://%s%s", protocol(r), bestNode, rPath)
-		rURL, err = resolveNodeUrl(rURL)
+		rURL, err = resolveNodeURL(rURL)
 		if err != nil {
 			glog.Errorf("failed to resolve node URL playbackID=%s err=%s", playbackID, err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -518,26 +518,26 @@ func streamSourceHandler() http.Handler {
 		}
 		streamName := string(b)
 		glog.V(7).Infof("got mist STREAM_SOURCE request=%s", streamName)
-		dtscUrl, err := queryMistForClosestNodeSource(streamName, "0", "0", "", true)
+		dtscURL, err := queryMistForClosestNodeSource(streamName, "0", "0", "", true)
 		if err != nil {
 			glog.Errorf("error querying mist for STREAM_SOURCE: %s", err)
 			w.Write([]byte("push://"))
 			return
 		}
-		outUrl, err := resolveNodeUrl(dtscUrl)
+		outURL, err := resolveNodeURL(dtscURL)
 		if err != nil {
 			glog.Errorf("error finding STREAM_SOURCE: %s", err)
 			w.Write([]byte("push://"))
 			return
 		}
-		glog.V(7).Infof("replying to Mist STREAM_SOURCE request=%s response=%s", streamName, outUrl)
-		w.Write([]byte(outUrl))
+		glog.V(7).Infof("replying to Mist STREAM_SOURCE request=%s response=%s", streamName, outURL)
+		w.Write([]byte(outURL))
 	})
 }
 
 // Given a dtsc:// or https:// url, resolve the proper address of the node via serf tags
-func resolveNodeUrl(streamUrl string) (string, error) {
-	u, err := url.Parse(streamUrl)
+func resolveNodeURL(streamURL string) (string, error) {
+	u, err := url.Parse(streamURL)
 	if err != nil {
 		return "", err
 	}
@@ -555,7 +555,7 @@ func resolveNodeUrl(streamUrl string) (string, error) {
 	addr, has := member.Tags[protocol]
 	if !has {
 		glog.V(7).Infof("no tag found, not tag resolving protocol=%s nodeName=%s", protocol, nodeName)
-		return streamUrl, nil
+		return streamURL, nil
 	}
 	u2, err := url.Parse(addr)
 	if err != nil {


### PR DESCRIPTION
A bunch of changes as we close in on the production deployment:

* Add `-advertise`, allowing catalyst-node to advertise an IP address that it's not actually binding to (needed for Kubernetes `hostPort` support)
* Add `-mist-load-balancer-template`, allowing us to specify alternate ports for Mist to query nodes. (needed for running Canary stuff on `:20443`)
* https://github.com/livepeer/catalyst/pull/150/commits/32be8fdb18513e27da12f8782251b2ae810c13a1, which checks `media=true` nodes for the load balancer (instead of matching the local node's tags)
* Added the ability for nodes to specify `http`, `https`, and `dtsc` tags, specifying non-default ports and hosts for connections. We're using this for the new rollout system; a new set of Catalyst pods can roll out on the same IPs with DTSC listening on (for example) 4201 instead of 4200 and traffic will get routed to them as appropriate.
  * To implement this, I've added a new internal HTTP server on port 8091 for handling internal Mist stream triggers and that sort of thing, similar to go-livepeer's 7935 server.

This is a little ugly right now - mostly the global `serfClient` variable. We're probably due for a refactor to give everything in here proper context, split into multiple files, etc. If anyone can think of a more elegant way to handle the `serfClient` situation sort of a full refactor, that'd be good.