### PR TITLE
catalyst-node: redirect query parameters on nodeHost redirect

### DIFF
--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -218,6 +218,33 @@ func TestNodeHostRedirect(t *testing.T) {
 		hasHeader("Location", "https://right-host/any/path")
 }
 
+func TestNodeHostPortRedirect(t *testing.T) {
+	hostCli := &catalystNodeCliFlags{NodeHost: "right-host:20443"}
+
+	requireReq(t, "http://wrong-host/any/path").
+		result(hostCli).
+		hasStatus(http.StatusFound).
+		hasHeader("Location", "http://right-host:20443/any/path")
+
+	requireReq(t, "http://wrong-host:1234/any/path").
+		result(hostCli).
+		hasStatus(http.StatusFound).
+		hasHeader("Location", "http://right-host:20443/any/path")
+
+	requireReq(t, "http://wrong-host:7777/any/path").
+		withHeader("X-Forwarded-Proto", "https").
+		result(hostCli).
+		hasStatus(http.StatusFound).
+		hasHeader("Location", "https://right-host:20443/any/path")
+
+	hostCli = &catalystNodeCliFlags{NodeHost: "right-host"}
+	requireReq(t, "http://wrong-host:7777/any/path").
+		withHeader("X-Forwarded-Proto", "https").
+		result(hostCli).
+		hasStatus(http.StatusFound).
+		hasHeader("Location", "https://right-host/any/path")
+}
+
 type httpReq struct {
 	*testing.T
 	*http.Request

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -206,6 +206,11 @@ func TestNodeHostRedirect(t *testing.T) {
 		hasStatus(http.StatusFound).
 		hasHeader("Location", "http://right-host/any/path")
 
+	requireReq(t, "http://wrong-host/any/path?foo=bar").
+		result(hostCli).
+		hasStatus(http.StatusFound).
+		hasHeader("Location", "http://right-host/any/path?foo=bar")
+
 	requireReq(t, "http://wrong-host/any/path").
 		withHeader("X-Forwarded-Proto", "https").
 		result(hostCli).


### PR DESCRIPTION
Needed for things like `audio=false` to work properly.