### PR TITLE
catalyst-node: 301 redirect instead of 302

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -487,7 +487,7 @@ func redirectHandler(redirectPrefixes []string, nodeHost string) http.Handler {
 				}
 				newURL.Scheme = protocol(r)
 				newURL.Host = nodeHost
-				http.Redirect(w, r, newURL.String(), http.StatusFound)
+				http.Redirect(w, r, newURL.String(), http.StatusMovedPermanently)
 				glog.V(6).Infof("NodeHost redirect host=%s nodeHost=%s from=%s to=%s", host, nodeHost, r.URL, newURL)
 				return
 			}
@@ -518,7 +518,7 @@ func redirectHandler(redirectPrefixes []string, nodeHost string) http.Handler {
 			return
 		}
 		glog.V(6).Infof("generated redirect url=%s", rURL)
-		http.Redirect(w, r, rURL, http.StatusFound)
+		http.Redirect(w, r, rURL, http.StatusMovedPermanently)
 	})
 }
 

--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -127,10 +127,9 @@ func runClient(config catalystConfig) error {
 		for _, member := range members {
 			memberHost := member.Name
 
-			// commented out as for now the load balancer does not return ports
-			//if member.Port != 0 {
-			//	memberHost = fmt.Sprintf("%s:%d", memberHost, member.Port)
-			//}
+			if member.Status != "alive" {
+				continue
+			}
 
 			membersMap[memberHost] = true
 		}


### PR DESCRIPTION
An experiment to see if this leads to better properties when doing a changeover.