### PR TITLE
catalyst-node: properly redirect query parameters

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -510,7 +510,7 @@ func redirectHandler(redirectPrefixes []string, nodeHost string) http.Handler {
 		}
 
 		rPath := fmt.Sprintf(pathTmpl, fullPlaybackID)
-		rURL := fmt.Sprintf("%s://%s%s", protocol(r), bestNode, rPath)
+		rURL := fmt.Sprintf("%s://%s%s?%s", protocol(r), bestNode, rPath, r.URL.RawQuery)
 		rURL, err = resolveNodeURL(rURL)
 		if err != nil {
 			glog.Errorf("failed to resolve node URL playbackID=%s err=%s", playbackID, err)

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -90,10 +90,10 @@ func getJSURLs(proto, host string) []string {
 	return urls
 }
 
-func getHLSURLsWithSeg(proto, host, seg string) []string {
+func getHLSURLsWithSeg(proto, host, seg, query string) []string {
 	var urls []string
 	for _, prefix := range prefixes {
-		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/%s/index.m3u8", proto, host, prefix, playbackID, seg))
+		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/%s/index.m3u8?%s", proto, host, prefix, playbackID, seg, query))
 	}
 	return urls
 }
@@ -160,7 +160,7 @@ func TestRedirectHandlerHLS_SegmentInPath(t *testing.T) {
 	requireReq(t, path).
 		result(nil).
 		hasStatus(http.StatusFound).
-		hasHeader("Location", getHLSURLsWithSeg("http", closestNodeAddr, seg)...)
+		hasHeader("Location", getHLSURLsWithSeg("http", closestNodeAddr, seg, getParams)...)
 }
 
 func TestRedirectHandlerHLS_InvalidPath(t *testing.T) {


### PR DESCRIPTION
One more place where we need to redirect query parameters.