### PR TITLE
catalyst-node: update string prefix matches for various vod sources

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -542,7 +542,7 @@ func streamSourceHandler(lat, lon float64) http.Handler {
 		glog.V(7).Infof("got mist STREAM_SOURCE request=%s", streamName)
 
 		// if VOD source is detected, return empty response to use input URL as configured
-		if strings.HasPrefix(streamName, "tr_src_") {
+		if strings.HasPrefix(streamName, "catalyst_vod_") || strings.HasPrefix(streamName, "tr_src_") {
 			w.Write([]byte(""))
 			return
 		}


### PR DESCRIPTION
**catalyst-node: update string prefix matches for various vod sources**

For vod sources, the SOURCE_STREAM trigger's response from catalyst-api
must be an empty field so that Mist uses the values configured in the
source field.

For /api/vod endpoint, source streams are added as catalyst_vod_*
prefix.
For /api/transcode/file endpoint, source streams are added as tr_src_*
prefix.

Check both prefixes and return with empty response body to Mist.