### PR TITLE
catalyst-node: crash on serf failures

### DIFF
--- a/cmd/catalyst-node/catalyst-node.go
+++ b/cmd/catalyst-node/catalyst-node.go
@@ -574,7 +574,7 @@ func resolveNodeURL(streamURL string) (string, error) {
 	nodeName := u.Host
 	protocol := u.Scheme
 
-	member, err := getSerfMember(nodeName)
+	member, err := getSerfMember(map[string]string{}, "alive", nodeName)
 	if err != nil {
 		return "", err
 	}
@@ -594,8 +594,12 @@ func resolveNodeURL(streamURL string) (string, error) {
 	return u2.String(), nil
 }
 
-func querySerfForMember(name string) (*serfclient.Member, error) {
-	members, err := serfClient.MembersFiltered(map[string]string{}, "alive", name)
+func membersFiltered(filter map[string]string, status, name string) ([]serfclient.Member, error) {
+	return serfClient.MembersFiltered(filter, status, name)
+}
+
+func member(filter map[string]string, status, name string) (*serfclient.Member, error) {
+	members, err := membersFiltered(map[string]string{}, status, name)
 	if err != nil {
 		return nil, err
 	}
@@ -608,7 +612,7 @@ func querySerfForMember(name string) (*serfclient.Member, error) {
 	return &members[0], nil
 }
 
-var getSerfMember = querySerfForMember
+var getSerfMember = member
 
 // return the best node available for a given stream. will return any node if nobody has the stream.
 func getBestNode(redirectPrefixes []string, playbackID, lat, lon, fallbackPrefix string) (string, string, error) {

--- a/cmd/catalyst-node/catalyst-node_test.go
+++ b/cmd/catalyst-node/catalyst-node_test.go
@@ -106,7 +106,7 @@ func TestRedirectHandler404(t *testing.T) {
 	defer func() { getClosestNode = defaultFunc }()
 
 	defaultSerf := getSerfMember
-	getSerfMember = func(string) (*serfclient.Member, error) { return fakeSerfMember, nil }
+	getSerfMember = func(map[string]string, string, string) (*serfclient.Member, error) { return fakeSerfMember, nil }
 	defer func() { getSerfMember = defaultSerf }()
 
 	path := fmt.Sprintf("/hls/%s/index.m3u8", playbackID)
@@ -130,7 +130,7 @@ func TestRedirectHandlerHLS_Correct(t *testing.T) {
 	}
 	defer func() { getClosestNode = defaultFunc }()
 	defaultSerf := getSerfMember
-	getSerfMember = func(string) (*serfclient.Member, error) { return fakeSerfMember, nil }
+	getSerfMember = func(map[string]string, string, string) (*serfclient.Member, error) { return fakeSerfMember, nil }
 	defer func() { getSerfMember = defaultSerf }()
 
 	path := fmt.Sprintf("/hls/%s/index.m3u8", playbackID)
@@ -154,7 +154,7 @@ func TestRedirectHandlerHLSVOD_Correct(t *testing.T) {
 	}
 	defer func() { getClosestNode = defaultFunc }()
 	defaultSerf := getSerfMember
-	getSerfMember = func(string) (*serfclient.Member, error) { return fakeSerfMember, nil }
+	getSerfMember = func(map[string]string, string, string) (*serfclient.Member, error) { return fakeSerfMember, nil }
 	defer func() { getSerfMember = defaultSerf }()
 
 	pathHLS := fmt.Sprintf("/hls/vod+%s/index.m3u8", playbackID)
@@ -189,7 +189,7 @@ func TestRedirectHandlerHLS_SegmentInPath(t *testing.T) {
 	getClosestNode = func(string, string, string, string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
 	defaultSerf := getSerfMember
-	getSerfMember = func(string) (*serfclient.Member, error) { return fakeSerfMember, nil }
+	getSerfMember = func(map[string]string, string, string) (*serfclient.Member, error) { return fakeSerfMember, nil }
 	defer func() { getSerfMember = defaultSerf }()
 
 	seg := "4_1"
@@ -215,7 +215,7 @@ func TestRedirectHandlerJS_Correct(t *testing.T) {
 	getClosestNode = func(string, string, string, string) (string, error) { return closestNodeAddr, nil }
 	defer func() { getClosestNode = defaultFunc }()
 	defaultSerf := getSerfMember
-	getSerfMember = func(string) (*serfclient.Member, error) { return fakeSerfMember, nil }
+	getSerfMember = func(map[string]string, string, string) (*serfclient.Member, error) { return fakeSerfMember, nil }
 	defer func() { getSerfMember = defaultSerf }()
 
 	path := fmt.Sprintf("/json_%s.js", playbackID)


### PR DESCRIPTION
This avoids the 500 error we've been seeing a lot.