### PR TITLE
Allow E2Es to handle new async VOD upload flow

### DIFF
--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -181,13 +181,12 @@ func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioCon
 	timeoutAt := time.Now().Add(5 * time.Second)
 
 	for {
-		if timeoutAt.Before(time.Now()) {
-			t.Error("Timed out while waiting for segmented output files to appear")
-		}
+		require.True(t, timeoutAt.After(time.Now()), "Timed out while waiting for segmented output files to appear")
 		files = []string{}
 		for o := range cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true}) {
 			files = append(files, o.Key)
 		}
+		fmt.Println("Waiting for 7 files, got:" , len(files))
 		if len(files) < 7 {
 			time.Sleep(100 * time.Millisecond)
 			continue

--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -186,7 +186,7 @@ func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioCon
 		for o := range cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true}) {
 			files = append(files, o.Key)
 		}
-		fmt.Println("Waiting for 7 files, got:" , len(files))
+		fmt.Println("Waiting for 7 files, got:", len(files))
 		if len(files) < 7 {
 			time.Sleep(100 * time.Millisecond)
 			continue

--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -184,13 +184,13 @@ func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioCon
 		if timeoutAt.Before(time.Now()) {
 			t.Error("Timed out while waiting for segmented output files to appear")
 		}
-		objects := cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true})
-		if len(objects) < 7 {
+		files = []string{}
+		for o := range cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true}) {
+			files = append(files, o.Key)
+		}
+		if len(files) < 7 {
 			time.Sleep(100 * time.Millisecond)
 			continue
-		}
-		for o := range objects {
-			files = append(files, o.Key)
 		}
 		break
 	}

--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -178,15 +178,15 @@ func processVod(t *testing.T, m *minioContainer, c *catalystContainer) {
 func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioContainer) {
 	cli := minioClient(t, m)
 	var files []string
+	var expectedNumFiles = 7
 	timeoutAt := time.Now().Add(5 * time.Minute)
 
 	for {
-		require.True(t, timeoutAt.After(time.Now()), "Timed out while waiting for segmented output files to appear")
+		require.True(t, timeoutAt.After(time.Now()), "Timed out while waiting for segmented output files to appear. Expected %d files but got %d", expectedNumFiles, len(files))
 		files = []string{}
 		for o := range cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true}) {
 			files = append(files, o.Key)
 		}
-		fmt.Println("Waiting for 7 files, got:", len(files))
 		if len(files) < 7 {
 			time.Sleep(500 * time.Millisecond)
 			continue
@@ -194,6 +194,7 @@ func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioCon
 		break
 	}
 
+	require.Equal(t, expectedNumFiles, len(files))
 	require.Contains(t, files, "source/output.m3u8")
 	require.Contains(t, files, "source/0.ts")
 	require.Contains(t, files, "source/11000.ts")

--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -178,7 +178,7 @@ func processVod(t *testing.T, m *minioContainer, c *catalystContainer) {
 func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioContainer) {
 	cli := minioClient(t, m)
 	var files []string
-	timeoutAt := time.Now().Add(5 * time.Second)
+	timeoutAt := time.Now().Add(5 * time.Minute)
 
 	for {
 		require.True(t, timeoutAt.After(time.Now()), "Timed out while waiting for segmented output files to appear")
@@ -188,7 +188,7 @@ func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioCon
 		}
 		fmt.Println("Waiting for 7 files, got:", len(files))
 		if len(files) < 7 {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			continue
 		}
 		break

--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -178,8 +178,21 @@ func processVod(t *testing.T, m *minioContainer, c *catalystContainer) {
 func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioContainer) {
 	cli := minioClient(t, m)
 	var files []string
-	for o := range cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true}) {
-		files = append(files, o.Key)
+	timeoutAt := time.Now().Add(5 * time.Second)
+
+	for {
+		if timeoutAt.Before(time.Now()) {
+			t.Error("Timed out while waiting for segmented output files to appear")
+		}
+		objects := cli.ListObjects(ctx, outBucket, minio.ListObjectsOptions{Recursive: true})
+		if len(objects) < 7 {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		for o := range objects {
+			files = append(files, o.Key)
+		}
+		break
 	}
 
 	require.Contains(t, files, "source/output.m3u8")


### PR DESCRIPTION
I tried to stand up a local HTTP server in the tests to catch callbacks, which would then let us wait on a "segmenting complete" callback rather than checking the number of files. This proved tricky though, because Catalyst is running in a container here and so can't reach a local HTTP endpoint outside that container.