### PR TITLE
Add transcoding to E2E

### DIFF
--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -184,10 +184,6 @@ func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioCon
 		"source/output.m3u8",
 		"source/source.mp4.dtsh",
 		"source/0.ts",
-		"source/11000.ts",
-		"source/17000.ts",
-		"source/23000.ts",
-		"source/29000.ts",
 		"source/5000.ts",
 	}
 

--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -51,7 +51,7 @@ func TestVod(t *testing.T) {
 	processVod(t, m, c)
 
 	// then
-	requireSegmentingOutputFiles(ctx, t, m)
+	requireOutputFiles(ctx, t, m)
 }
 
 type minioContainer struct {
@@ -175,16 +175,30 @@ func processVod(t *testing.T, m *minioContainer, c *catalystContainer) {
 	defer resp.Body.Close()
 }
 
-func requireSegmentingOutputFiles(ctx context.Context, t *testing.T, m *minioContainer) {
+func requireOutputFiles(ctx context.Context, t *testing.T, m *minioContainer) {
 	cli := minioClient(t, m)
 	var files []string
 	timeoutAt := time.Now().Add(5 * time.Minute)
 
 	expectedFiles := []string{
-		"source/output.m3u8",
+		"index.m3u8",
+
 		"source/source.mp4.dtsh",
+		"source/output.m3u8",
 		"source/0.ts",
 		"source/5000.ts",
+
+		"360p0/index.m3u8",
+		"360p0/0.ts",
+		"360p0/1.ts",
+
+		"720p0/index.m3u8",
+		"720p0/0.ts",
+		"720p0/1.ts",
+
+		"1080p0/index.m3u8",
+		"1080p0/0.ts",
+		"1080p0/1.ts",
 	}
 
 	for {


### PR DESCRIPTION
I think we should also get rid of `mist_config.go` and use the same sample configs we use for the local runs. But I see it as a separate PR.