### PR TITLE
Update test assertion to reflect new Mist segmenting logic

### DIFF
--- a/test/e2e/vod_test.go
+++ b/test/e2e/vod_test.go
@@ -186,7 +186,7 @@ func requireOutputFiles(ctx context.Context, t *testing.T, m *minioContainer) {
 		"source/source.mp4.dtsh",
 		"source/output.m3u8",
 		"source/0.ts",
-		"source/5000.ts",
+		"source/6000.ts",
 
 		"360p0/index.m3u8",
 		"360p0/0.ts",


### PR DESCRIPTION
The "split" var that we now pass to Mist (set to 5) contains the minimum duration of segments in seconds. 

5 = 5000, which means the first possible split is at 5001. If the keyframes are at every exact whole integer like in the test video we use then the closest cutting point > 5000 is 6000