### PR TITLE
Add livepeer-w3 to catalyst docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN	strip -s /opt/bin/*
 
 FROM	catalyst-${BUILD_TARGET}-build	as	catalyst-build
 
+# Install livepeer-w3 required to use web3.storage
+FROM	node:18.14.0 as node-build
+ARG	LIVEPEER_W3_VERSION=v0.2.2
+WORKDIR /app
+RUN	git clone --depth 1 --branch ${LIVEPEER_W3_VERSION} https://github.com/livepeer/go-tools.git
+RUN	npm install --prefix /app/go-tools/w3
+
 FROM	ubuntu:20.04	AS	catalyst
 
 ENV	DEBIAN_FRONTEND=noninteractive
@@ -47,15 +54,20 @@ LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"
 
 ARG	BUILD_TARGET
 
+RUN	apt update && apt install -yqq wget
+RUN	wget -O - https://deb.nodesource.com/setup_18.x | bash
 RUN	apt update && apt install -yqq \
 	ca-certificates \
 	musl \
 	python3 \
 	ffmpeg \
+    	nodejs \
 	"$(if [ "$BUILD_TARGET" != "stripped" ]; then echo "gdb"; fi)" \
 	&& rm -rf /var/lib/apt/lists/*
 
-COPY --from=catalyst-build	/opt/bin/	/usr/local/bin/
+COPY --from=catalyst-build	/opt/bin/		/usr/local/bin/
+COPY --from=node-build		/app/go-tools/w3	/opt/local/lib/livepeer-w3
+RUN	ln -s /opt/local/lib/livepeer-w3/livepeer-w3.js /usr/local/bin/livepeer-w3
 
 EXPOSE	1935	4242	8080	8889/udp
 


### PR DESCRIPTION
We need a nodejs script in order to upload files into web3.storage.

It increases the Docker images size `2.22GB` => `2.46GB`

For the context, please check this PR: https://github.com/livepeer/go-tools/pull/17

fix https://github.com/livepeer/catalyst/issues/373