### PR TITLE
ci: try building platforms in parallel too

### DIFF
--- a/.github/workflows/catalyst.yaml
+++ b/.github/workflows/catalyst.yaml
@@ -1,4 +1,4 @@
-name: Build and publish catalyst docker images
+name: Docker build
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   catalyst:
-    name: Build and publish docker image for catalyst-${{ matrix.build.target }}
+    name: livepeerci/catalyst${{ matrix.targets.suffix }}${{ matrix.build.suffix }}
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
This would unblock deploys for the common `-amd64` case while still eventually pushing a multi-arch `amd64/arm64` build by the end.