### PR TITLE
livepeer-log: handle log lines longer than 64k

### DIFF
--- a/cmd/livepeer-log/livepeer-log.go
+++ b/cmd/livepeer-log/livepeer-log.go
@@ -143,7 +143,7 @@ func main() {
 			panic(err)
 		}
 
-		print := func(text string) {
+		output := func(text string) {
 			fmt.Fprintf(os.Stderr, "INFO|%s|%d|||%s\n", procname, mypid, text)
 		}
 
@@ -155,12 +155,12 @@ func main() {
 				for {
 					line, isPrefix, err := reader.ReadLine()
 					if err != nil {
-						print(fmt.Sprintf("reader gave error, ending logging for fd=%d err=%s", i+1, err))
+						output(fmt.Sprintf("reader gave error, ending logging for fd=%d err=%s", i+1, err))
 						break
 					}
-					print(string(line))
+					output(string(line))
 					if isPrefix {
-						print("warning: preceeding line exceeds 64k logging limit and was split")
+						output("warning: preceeding line exceeds 64k logging limit and was split")
 					}
 				}
 			}(i, pipe)

--- a/cmd/livepeer-log/livepeer-log.go
+++ b/cmd/livepeer-log/livepeer-log.go
@@ -169,7 +169,7 @@ func main() {
 							return err
 						}
 						if isPrefix {
-							output("warning: preceeding line exceeds 64k logging limit and was split")
+							output("warning: preceding line exceeds 64k logging limit and was split")
 						}
 					}
 				})

--- a/cmd/livepeer-log/livepeer-log.go
+++ b/cmd/livepeer-log/livepeer-log.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/livepeer/livepeer-data/pkg/mistconnector"
+	"golang.org/x/sync/errgroup"
 )
 
 func main() {
@@ -128,6 +130,8 @@ func main() {
 	cmd := exec.Command(os.Args[1], rest...)
 	cmd.Stdin = os.Stdin
 
+	group, _ := errgroup.WithContext(context.Background())
+
 	if dashJ {
 		// If they did -j, don't mangle the output
 		cmd.Stdout = os.Stdout
@@ -149,20 +153,26 @@ func main() {
 
 		// Actually print with lots of lines!
 		for i, pipe := range []io.ReadCloser{stdout, stderr} {
-			go func(i int, pipe io.ReadCloser) {
-				reader := bufio.NewReader(pipe)
+			func(i int, pipe io.ReadCloser) {
+				group.Go(func() error {
+					reader := bufio.NewReader(pipe)
 
-				for {
-					line, isPrefix, err := reader.ReadLine()
-					if err != nil {
-						output(fmt.Sprintf("reader gave error, ending logging for fd=%d err=%s", i+1, err))
-						break
+					for {
+						line, isPrefix, err := reader.ReadLine()
+						if string(line) != "" {
+							output(string(line))
+						}
+						if err != nil {
+							output(fmt.Sprintf("reader gave error, ending logging for fd=%d err=%s", i+1, err))
+							line, _, err := reader.ReadLine()
+							output(string(line))
+							return err
+						}
+						if isPrefix {
+							output("warning: preceeding line exceeds 64k logging limit and was split")
+						}
 					}
-					output(string(line))
-					if isPrefix {
-						output("warning: preceeding line exceeds 64k logging limit and was split")
-					}
-				}
+				})
 			}(i, pipe)
 		}
 
@@ -187,12 +197,19 @@ func main() {
 	}()
 
 	// Fire away!
-	progerr := cmd.Run()
+	progerr := cmd.Start()
 	if progerr != nil {
-		newerr := fmt.Sprintf("%s - invocation %s", progerr.Error(), strings.Join(os.Args, " "))
+		newerr := fmt.Errorf("%s - invocation %s", progerr.Error(), strings.Join(os.Args, " "))
 		panic(newerr)
 	}
-	os.Exit(0)
+
+	group.Wait()
+
+	progerr = cmd.Wait()
+	if progerr != nil {
+		newerr := fmt.Errorf("%s - invocation %s", progerr.Error(), strings.Join(os.Args, " "))
+		panic(newerr)
+	}
 }
 
 func printJSONInfo(jsonInfo mistconnector.MistConfig) {

--- a/cmd/livepeer-log/livepeer-log_test.go
+++ b/cmd/livepeer-log/livepeer-log_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLongOutput(t *testing.T) {
+	testPath, err := filepath.Abs("log_spam_test.sh")
+	require.NoError(t, err)
+	c, b := exec.Command("go", "run", "livepeer-log.go", testPath), new(strings.Builder)
+	c.Stderr = b
+	err = c.Run()
+	require.NoError(t, err)
+	require.True(t, strings.Contains(b.String(), "success"))
+}

--- a/cmd/livepeer-log/log_spam_test.sh
+++ b/cmd/livepeer-log/log_spam_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+openssl rand -hex 4096
+echo ""
+echo "success"
+echo ""

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.3.0
 	github.com/stretchr/testify v1.8.1
 	github.com/testcontainers/testcontainers-go v0.13.1-0.20220712105725-8e65673ca167
+	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -862,6 +862,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
We were previously using `bufio.Scanner` that stops scanning when it hits a line too long. We don't want that. `bufio.Reader` does what we want.