### PR TITLE
ci: cross-compile livepeer-log and catalyst

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     name: Build and download binaries from manifest for ${{ matrix.platform.name }}-${{ matrix.architecture }}
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It's faster. [4m42s](https://github.com/livepeer/catalyst/actions/runs/4874482388/jobs/8695477165) down from [9m32s](https://github.com/livepeer/catalyst/actions/runs/4874239090).