### PR TITLE
E2E: Highlight error detail msg

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -288,25 +288,7 @@ func requireReplicatedStream(t *testing.T, c *catalystContainer) {
 		glog.Info("Got HLS manifest!")
 		return true
 	}
-	require.Eventually(t, correctStream, 5*time.Minute, time.Second, errorMsg)
-}
-
-func requireNotReplicatedStream(t *testing.T, c *catalystContainer) {
-	require := require.New(t)
-
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/hls/stream+foo/index.m3u8", c.http))
-	require.NoError(err)
-
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(err)
-
-	content := string(body)
-	for _, expected := range []string{"RESOLUTION=1920x1080", "FRAME-RATE=30", "index.m3u8"} {
-		if strings.Contains(content, expected) {
-			require.Fail("Stream should not be replicated", "Received replicated stream '%s'", content)
-		}
-	}
+	require.Eventually(t, correctStream, 5*time.Minute, time.Second, fmt.Sprintf("Error Detail: %s", errorMsg))
 }
 
 func requireStreamRedirection(t *testing.T, c1 *catalystContainer, c2 *catalystContainer) {


### PR DESCRIPTION
We hit this failure again but didn't get any error detail 
<img width="1364" alt="image" src="https://github.com/livepeer/catalyst/assets/907370/b65f232e-e167-4df8-8290-85b20912559e">
so adding surrounding text as a sanity check