### PR TITLE
Revert "Manually update catalyst-api SHA to deploy on its own (#563)"

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,7 +24,7 @@ box:
     strategy:
       download: bucket
       project: catalyst-api
-      commit: 6e783719d968be189eef011c024577e920ee4e20
+      commit: e11b04dded935d55c3da4eb424316b9ed1c627c9
     release: main
     srcFilenames:
       darwin-amd64: livepeer-catalyst-api-darwin-amd64.tar.gz

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -305,7 +305,7 @@ func requireStreamRedirection(t *testing.T, c1 *catalystContainer, c2 *catalystC
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusTemporaryRedirect {
+		if resp.StatusCode != http.StatusFound {
 			return false
 		}
 


### PR DESCRIPTION
Creating this just in case we have issues in prod and need to roll back

This reverts commit a99f0c4d473c9bfa9011121d0c04cd05cecc5055.