### PR TITLE
Bump catalyst-api to latest

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,7 +24,7 @@ box:
     strategy:
       download: bucket
       project: catalyst-api
-      commit: 6e783719d968be189eef011c024577e920ee4e20
+      commit: 645845f28bbdd93a0764c62e9e9cb2bf62212f4f
     release: main
     srcFilenames:
       darwin-amd64: livepeer-catalyst-api-darwin-amd64.tar.gz


### PR DESCRIPTION
Not sure the exact state of the Mist stuff, so wanted to avoid using the automated PR