### PR TITLE
ci: fixes to the staging manifest generator

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -42,6 +42,8 @@ jobs:
       - name: Commit and push changes
         id: branch-commit
         uses: devops-infra/action-commit-push@v0.9.2
+        env:
+          GIT_COMMITTER_DATE: "Fri Sep 8 10:55:23 2023 -0700"
         with:
           github_token: ${{ secrets.PUSH_TOKEN }}
           target_branch: staging

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: devops-infra/action-commit-push@v0.9.2
         env:
           GIT_COMMITTER_DATE: "Fri Sep 8 10:55:23 2023 -0700"
+          GIT_AUTHOR_DATE: "Fri Sep 8 10:55:23 2023 -0700"
         with:
           github_token: ${{ secrets.PUSH_TOKEN }}
           target_branch: staging

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -3,6 +3,10 @@ name: Generate staging manifest
 on:
   repository_dispatch:
     types: ["staging-manifest"]
+  # the push is for hacking on this without pushing to the main branch of catalyst
+  push:
+    branches:
+      - staging-generator
 
 jobs:
   staging-manifest:


### PR DESCRIPTION
Two changes:

1. Add a `staging-generator` branch that rebuilds the staging manifest on push for the purpose of testing this without constantly pushing to `main`
2. Hardcodes `GIT_COMMITTER_DATE` and `GIT_AUTHOR_DATE` so they're deterministic and we stop getting this:
![image](https://github.com/livepeer/catalyst/assets/257909/62b73447-dfda-40bf-9963-0b24c31b4a8f)
I don't know why that's happening; the "don't push if there aren't any changes" rule was either broken by https://github.com/livepeer/catalyst/commit/1967fcb74e37b862dafb4d7f60439954845f394f or by https://github.com/livepeer/catalyst/commit/7b360973c032af16727afebc3adc3cabf8fc425b. 

The downside to this is that the dates on the automerge commits will be wrong and that's annoying. An alternative would be to query the last-modified times on all the bucket files and use the latest of them:
```
curl --head --silent https://build.livepeer.live/livepeer-data/main.json | grep last-modified
last-modified: Thu, 07 Sep 2023 10:44:19 GMT
```
But I'm going to merge this now to unbreak the staging CI process; it's important.