### PR TITLE
Speed up Catalyst build by not building c2patool from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN	apt update && apt install -yqq \
 ADD	./scripts/livepeer-vmagent	/usr/local/bin
 
 COPY --from=catalyst-build	/opt/bin/		/usr/local/bin/
-COPY --from=gobuild		/c2patool /bin/
+COPY --from=gobuild		/go/c2patool /bin/
 COPY --from=node-build		/app/go-tools/w3	/opt/local/lib/livepeer-w3
 
 RUN	ln -s /opt/local/lib/livepeer-w3/livepeer-w3.js /usr/local/bin/livepeer-w3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ARG TARGETARCH
 
 # Download c2patool needed to sign our C2PA manifest
 # We download it from any of our previous builds, because building c2patool from source is very slow with QEMU
-ADD https://build.livepeer.live/catalyst/772a57003e6d96c9a47ef18fccb51a0c61207074/livepeer-catalyst-linux-${TARGETARCH}.tar.gz /catalyst/
+ADD https://build.livepeer.live/catalyst/772a57003e6d96c9a47ef18fccb51a0c61207074/livepeer-catalyst-linux-${TARGETARCH}.tar.gz /catalyst.tar.gz
+RUN tar xzf /catalyst.tar.gz
 
 WORKDIR	/src
 
@@ -83,7 +84,7 @@ RUN	apt update && apt install -yqq \
 ADD	./scripts/livepeer-vmagent	/usr/local/bin
 
 COPY --from=catalyst-build	/opt/bin/		/usr/local/bin/
-COPY --from=gobuild		/catalyst/c2patool /bin/
+COPY --from=gobuild		/c2patool /bin/
 COPY --from=node-build		/app/go-tools/w3	/opt/local/lib/livepeer-w3
 
 RUN	ln -s /opt/local/lib/livepeer-w3/livepeer-w3.js /usr/local/bin/livepeer-w3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ ARG	FROM_LOCAL_PARENT
 
 FROM	golang:1-bullseye	as	gobuild
 
+ARG TARGETARCH
+
+# Download c2patool needed to sign our C2PA manifest
+# We download it from any of our previous builds, because building c2patool from source is very slow with QEMU
+ADD https://build.livepeer.live/catalyst/772a57003e6d96c9a47ef18fccb51a0c61207074/livepeer-catalyst-linux-${TARGETARCH}.tar.gz /catalyst/
+
 WORKDIR	/src
 
 ADD	go.mod go.sum	./
@@ -50,9 +56,6 @@ RUN	git clone --depth 1 --branch ${LIVEPEER_W3_VERSION} https://github.com/livep
 	&& npm install --prefix /app/go-tools/w3 \
 	&& chown -R root:root /app/go-tools/w3
 
-FROM	rust:1.73.0 as rust-build
-RUN	cargo install --version 0.6.2 c2patool
-
 FROM	ubuntu:22.04	AS	catalyst
 
 ENV	DEBIAN_FRONTEND=noninteractive
@@ -80,7 +83,7 @@ RUN	apt update && apt install -yqq \
 ADD	./scripts/livepeer-vmagent	/usr/local/bin
 
 COPY --from=catalyst-build	/opt/bin/		/usr/local/bin/
-COPY --from=rust-build 		/usr/local/cargo/bin/c2patool /bin/
+COPY --from=gobuild		/catalyst/c2patool /bin/
 COPY --from=node-build		/app/go-tools/w3	/opt/local/lib/livepeer-w3
 
 RUN	ln -s /opt/local/lib/livepeer-w3/livepeer-w3.js /usr/local/bin/livepeer-w3 \


### PR DESCRIPTION
The proper solution is to implement this: https://github.com/contentauth/c2patool/issues/149

In the meantime, however, since our build currently takes crazy ~1.5h, I added this hack to download c2patool from our own binaries instead of building it from sources. It's not too elegant, but speeds up our build CI significantly.