### PR TITLE
ci: livepeer/catalyst-lite

### DIFF
--- a/.github/workflows/catalyst.yaml
+++ b/.github/workflows/catalyst.yaml
@@ -52,15 +52,16 @@ jobs:
             target_suffix: "-arm64"
             debug_suffix: "-debug"
         docker_images:
+          - target: catalyst-lite
+            label: livepeer/catalyst-lite
+            refs: |
+              livepeer/catalyst-lite
+              livepeerci/catalyst
+            # ghcr.io/livepeer/catalyst
           - target: catalyst
             label: livepeer/catalyst
             refs: |
               livepeer/catalyst
-              livepeerci/catalyst
-            # ghcr.io/livepeer/catalyst
-          - target: livepeer-in-a-box
-            label: livepeer/in-a-box
-            refs: |
               livepeer/in-a-box
               livepeerci/in-a-box
             # ghcr.io/livepeer/in-a-box


### PR DESCRIPTION
New proposed organization with Catalyst rebrand:

### Lite Build

* Includes Catalyst but not some of the surrounding, heavier apps for the full stack like RabbitMQ.
* Main tag: `livepeer/catalyst-lite`
* Additional tags: `livepeerci/catalyst` (so Studio can continue to use as-is)

### Full Build

* Includes RabbitMQ, CockroachDB, MinIO, and everything else necessary for the "full-stack" Catalyst
* Main tag: `livepeer/catalyst`
* Additional tags: `livepeer/in-a-box` (for legacy support)