### PR TITLE
tknMode=11

### DIFF
--- a/config/full-stack.json
+++ b/config/full-stack.json
@@ -212,7 +212,7 @@
     "sessionStreamInfoMode": 1,
     "sessionUnspecifiedMode": 0,
     "sessionViewerMode": 14,
-    "tknMode": 15,
+    "tknMode": 11,
     "triggers": {},
     "trustedproxy": ["0.0.0.0/1", "128.0.0.0/1"]
   },


### PR DESCRIPTION
Changing mist's `tknMode=15` into `tknMode=11` so it supports being served from behind CDN 
[Discord](https://discord.com/channels/423160867534929930/1171837357893361836/1179693607511396423)

> 11 sets bits 0(=1), 1(=2), and 3(=8). Those meaning reading+writing token from/to cookie, and reading from GET param (but not writing/setting to GET param - bit 2(=4)). As long as that bit isn't set, CDN mode is activated (since most CDNs usually ignore cookies, so they don't affect anything).