### PR TITLE
Speed up Catalyst build by downloading c2patool binary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Download c2patool
         run: |
-          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-linux-${{ matrix.architecture }}" -o c2patool.tar.gz
+          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-{{ matrix.platform.name }}-${{ matrix.architecture }}" -o c2patool.tar.gz
           tar -xvzf c2patool.tar.gz -C ./bin/c2patool
 
       - name: Strip binaries of debug symbols

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Download c2patool
         run: |
-          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-{{ matrix.platform.name }}-${{ matrix.architecture }}" -o c2patool.tar.gz
+          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}" -o c2patool.tar.gz
           tar -xvzf c2patool.tar.gz -C ./bin/c2patool
 
       - name: Strip binaries of debug symbols

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,16 +83,10 @@ jobs:
       - name: Configure Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build c2patool
-        uses: baptiste0928/cargo-install@v2
-        with:
-          crate: c2patool
-          version: "0.6.2"
-          cache-key: "${{ matrix.platform.name }}-${{ matrix.architecture }}"
-
-      - name: Copy c2patool
+      - name: Download c2patool
         run: |
-          cp "${HOME}/.cargo/bin/c2patool" ./bin/c2patool
+          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-linux-${{ matrix.architecture }}" -o c2patool.tar.gz
+          tar -xvzf c2patool.tar.gz -C ./bin/c2patool
 
       - name: Strip binaries of debug symbols
         if: matrix.platform.name == 'linux' && matrix.architecture == 'amd64'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Download c2patool
         run: |
-          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}.tar.gz" -o c2patool.tar.gz
+          curl "https://build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}.tar.gz" -o c2patool.tar.gz
           tar -xvzf c2patool.tar.gz -C ./bin/
 
       - name: Strip binaries of debug symbols

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Download c2patool
         run: |
           curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}.tar.gz" -o c2patool.tar.gz
-          tar -xvzf c2patool.tar.gz -C ./bin/c2patool
+          tar -xvzf c2patool.tar.gz -C ./bin/
 
       - name: Strip binaries of debug symbols
         if: matrix.platform.name == 'linux' && matrix.architecture == 'amd64'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Download c2patool
         run: |
-          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}" -o c2patool.tar.gz
+          curl "https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}.tar.gz" -o c2patool.tar.gz
           tar -xvzf c2patool.tar.gz -C ./bin/c2patool
 
       - name: Strip binaries of debug symbols

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,12 +77,6 @@ jobs:
 
           cp ./scripts/livepeer-vmagent ./bin/livepeer-vmagent
 
-      - name: Cleanup ~/.rustup
-        run: rm -rf ~/.rustup
-
-      - name: Configure Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Download c2patool
         run: |
           curl "https://build.livepeer.live/c2patool/0.6.2/c2patool-${{ matrix.platform.name }}-${{ matrix.architecture }}.tar.gz" -o c2patool.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 RUN	apt update && apt install -yqq \
 	curl \
 	ca-certificates
-RUN curl https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz
+RUN curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz
 RUN tar xzf /c2patool.tar.gz
 
 WORKDIR	/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ARG TARGETARCH
 # We download it from any of our previous builds, because building c2patool from source is very slow with QEMU
 RUN	apt update && apt install -yqq \
 	curl \
-	ca-certificates
-RUN curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz
-RUN tar xzf /c2patool.tar.gz
+	ca-certificates \
+	&& curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz
+	&& tar xzf /c2patool.tar.gz
 
 WORKDIR	/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ARG TARGETARCH
 RUN	apt update && apt install -yqq \
 	curl \
 	ca-certificates
-RUN curl https://storage.googleapis.com/build.livepeer.live/catalyst/772a57003e6d96c9a47ef18fccb51a0c61207074/livepeer-catalyst-linux-${TARGETARCH}.tar.gz -o /catalyst.tar.gz
-RUN tar xzf /catalyst.tar.gz
+RUN curl https://storage.googleapis.com/build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz
+RUN tar xzf /c2patool.tar.gz
 
 WORKDIR	/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 RUN	apt update && apt install -yqq \
 	curl \
 	ca-certificates \
-	&& curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz
+	&& curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz \
 	&& tar xzf /c2patool.tar.gz
 
 WORKDIR	/src


### PR DESCRIPTION
Speed up Catalyst build by downloading c2patool binary (instead of building it from source)