### PR TITLE
[ENG-1889] manifest: Skip manifest updation for mistserver releases

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -65,6 +65,7 @@ box:
       commit: 014094222fe2a3cbb8ebf2ca43c12546c73090cc
     release: catalyst
     skipGpg: true
+    skipManifestUpdate: true
     srcFilenames:
       darwin-amd64: livepeer-mistserver-darwin-amd64.tar.gz
       darwin-arm64: livepeer-mistserver-darwin-arm64.tar.gz


### PR DESCRIPTION
MistServer would need to be manually updated.