### PR TITLE
manifest: update catalyst-api version commit

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,7 +24,7 @@ box:
     strategy:
       download: bucket
       project: catalyst-api
-      commit: 72dfb53dbe1eda425367a95159d82f17a242b120
+      commit: cb6dce39167a66c2b31cf7cb7307a9d85c65173a
     release: main
     srcFilenames:
       darwin-amd64: livepeer-catalyst-api-darwin-amd64.tar.gz


### PR DESCRIPTION
For staging, this include:
- unrevert of commits after the multistream rollback
- [transcode,video: Add support for copying HLS input segments (](https://github.com/livepeer/catalyst-api/commit/c31e2b5549402e88a1daf067e7f391a35d2bc956)https://github.com/livepeer/catalyst-api/pull/1261[)](https://github.com/livepeer/catalyst-api/commit/c31e2b5549402e88a1daf067e7f391a35d2bc956)
- [access-control: use whole acReq payload as cacheKey (](https://github.com/livepeer/catalyst-api/commit/cb6dce39167a66c2b31cf7cb7307a9d85c65173a)https://github.com/livepeer/catalyst-api/pull/1267[)](https://github.com/livepeer/catalyst-api/commit/cb6dce39167a66c2b31cf7cb7307a9d85c65173a)