### PR TITLE
Bump ffmpeg version from 6 -> 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ARG	BUILD_TARGET
 
 RUN	apt update && apt install -yqq wget software-properties-common \
 	&& wget -O - https://deb.nodesource.com/setup_18.x | bash \
-	&& add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg6
+	&& add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
 
 RUN	apt update && apt install -yqq \
 	curl \


### PR DESCRIPTION
This is to fix a segmenting bug identified by Josh in https://linear.app/livepeer/issue/PS-551/vod-issues-cannot-play-asset as being fixed in version 7, whereby segments beyond the first one are missing SPS/PPS values and so aren't independently decodable (which then breaks VOD transcoding).