### PR TITLE
INF-399 Fix warnings failing tests

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ warningCode = 0
     Disabled = true
 
 [rule.package-comments]
-  Disabled = true
+    Disabled = true
 
 [rule.blank-imports]
 [rule.context-as-argument]

--- a/config.toml
+++ b/config.toml
@@ -2,13 +2,13 @@ ignoreGeneratedHeader = false
 severity = "warning"
 confidence = 0.8
 errorCode = 1
-warningCode = 1
+warningCode = 0
 
 [rule.exported]
     Disabled = true
 
 [rule.package-comments]
-    Disabled = true
+  Disabled = true
 
 [rule.blank-imports]
 [rule.context-as-argument]


### PR DESCRIPTION
These tests have been failing: https://github.com/livepeer/catalyst/actions/workflows/test.yaml
> Run docker://morphy/revive-action:v2
> Failures
>   Warning: avoid meaningless package names
>   Warning: avoid meaningless package names

Warnings like these should not fail the whole workflow